### PR TITLE
Removed max_concurrency default.

### DIFF
--- a/qpc/messages.py
+++ b/qpc/messages.py
@@ -124,7 +124,7 @@ SCAN_TYPE_FILTER_HELP = 'Filter for listing scan jobs by type. Valid '\
 SCAN_STATUS_FILTER_HELP = 'Filter for listing scan jobs by status. Valid '\
     'values: created, pending, running, paused, canceled, completed, failed.'
 SCAN_MAX_CONCURRENCY_HELP = 'Maximum number of concurrent scans; '\
-    'default is 50.'
+    'default is 25.'
 SCAN_RESULTS_HELP = 'View results of the specified scan.'
 SCAN_DOES_NOT_EXIST = 'Scan "%s" does not exist.'
 SCAN_JOB_DOES_NOT_EXIST = 'Scan job "%s" does not exist.'

--- a/qpc/scan/add.py
+++ b/qpc/scan/add.py
@@ -51,7 +51,7 @@ class ScanAddCommand(CliCommand):
                                  required=True)
         self.parser.add_argument('--max-concurrency', dest='max_concurrency',
                                  metavar='MAX_CONCURRENCY',
-                                 type=int, default=50,
+                                 type=int, required=False,
                                  help=_(messages.SCAN_MAX_CONCURRENCY_HELP))
         self.parser.add_argument('--disabled-optional-products',
                                  dest='disabled_optional_products',
@@ -96,9 +96,11 @@ class ScanAddCommand(CliCommand):
             'name': self.args.name,
             'sources': self.source_ids,
             'scan_type': scan.SCAN_TYPE_INSPECT,
-            'options': {
-                'max_concurrency': self.args.max_concurrency}
+            'options': {}
         }
+        if self.args.max_concurrency:
+            self.req_payload['options']['max_concurrency'] \
+                = self.args.max_concurrency
         disabled_optional_products \
             = get_optional_products(self.args.disabled_optional_products)
         enabled_ext_product_search \


### PR DESCRIPTION
Removed max concurrency default for: 

https://github.com/quipucords/quipucords/issues/1858

Tests: 
```
+ qpc scan add --name VScan --sources VSource
Scan "VScan" was added.
qpc
+ qpc scan list
[
    {
        "id": 1,
        "name": "VScan",
        "options": {
            "max_concurrency": 25
        },
        "scan_type": "inspect",
        "sources": [
            {
                "id": 1,
                "name": "VSource",
                "source_type": "vcenter"
            }
        ]
    }
]
```
