### PR TITLE
Pin pydocstyle in tox.ini

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -27,6 +27,7 @@ commands =
 [testenv:lint]
 deps =
   flake8 == 3.7.7
+  pydocstyle == 3.0.0
   flake8-docstrings
   flake8-import-order
   flake8-quotes


### PR DESCRIPTION
pin pydocstyle due to the current issue https://gitlab.com/pycqa/flake8-docstrings/issues/36