### PR TITLE
Added password arg to server login

### DIFF
--- a/docs/source/man.rst
+++ b/docs/source/man.rst
@@ -90,11 +90,15 @@ Logging in to the server
 
 To log in to the server after the connection is configured, use the ``login`` subcommand. This command retrieves a token that is used for authentication with any command line interface commands that follow it.
 
-**qpc server login [--username=** *username* **]**A source defines the entity to be inspected, such as a host, subnet, network, or systems management solution such as vCenter Server or Satellite, plus includes one or more credentials to use to access that network or systems management solution during the inspection process.
+**qpc server login [--username=** *username* **] [--password=** *password* **]**
 
 ``--username=username``
 
-  Optional. Sets the user name that is used to log in to the server.
+  Optional. Sets the user name that is used to log in to the server. If omitted, qpc will prompt for the server username.
+
+``--password=password``
+
+  Optional. Sets the password that is used to log in to the server. If omitted, qpc will prompt for the server password.
 
 
 Logging out of the server

--- a/qpc.spec
+++ b/qpc.spec
@@ -68,7 +68,8 @@ install -D -p -m 644 docs/qpc.1 $RPM_BUILD_ROOT%{_mandir}/man1/qpc.1
 
 %changelog
 * Thu Nov 14 2019 Kevan Holdaway <kholdawa@redhat.com> 0.9.3-1
-- Bump version to 0.9.3 for master branch
+- Bump version to 0.9.3 for master branch. <kholdawa@redhat.com>
+- Added password arg to server login. <cmyers@redhat.com>
 * Thu Nov 14 2019 Ashley Aiken <aaiken@redhat.com> 0.9.2-1
 - Bump version to 0.9.2 for master branch
 - Dependency version updates

--- a/qpc/messages.py
+++ b/qpc/messages.py
@@ -263,7 +263,10 @@ SERVER_STATUS_FAILURE = 'Unexpected failure occurred when accessing the '\
 STATUS_PATH_HELP = 'Output file location.'
 STATUS_SUCCESSFULLY_WRITTEN = 'Server status written successfully.'
 
-LOGIN_USER_HELP = 'The user name to log in to the server.'
+LOGIN_USER_HELP = 'The user name to log in to the server. If not provided, '\
+    'user will be prompted.'
+LOGIN_PASS_HELP = 'The password to log in to the server. If not provided, '\
+    'user will be prompted.'
 LOGIN_USERNAME_PROMPT = 'User name: '
 LOGIN_SUCCESS = 'Login successful.'
 

--- a/qpc/server/login_host.py
+++ b/qpc/server/login_host.py
@@ -46,6 +46,10 @@ class LoginHostCommand(CliCommand):
                                  metavar='USERNAME',
                                  help=_(messages.LOGIN_USER_HELP),
                                  required=False)
+        self.parser.add_argument('--password', dest='password',
+                                 metavar='PASSWORD',
+                                 help=_(messages.LOGIN_PASS_HELP),
+                                 required=False)
         self.username = None
         self.password = None
 
@@ -59,7 +63,10 @@ class LoginHostCommand(CliCommand):
         else:
             self.username = input(_(messages.LOGIN_USERNAME_PROMPT))
 
-        self.password = getpass()
+        if 'password' in self.args and self.args.password:
+            self.password = self.args.password
+        else:
+            self.password = getpass()
 
     def _build_data(self):
         """Construct the dictionary credential given our arguments.

--- a/qpc/server/tests_login_host.py
+++ b/qpc/server/tests_login_host.py
@@ -16,6 +16,7 @@ from unittest.mock import patch
 from argparse import ArgumentParser, Namespace  # noqa: I100
 from io import StringIO
 
+from qpc import messages
 from qpc.server import LOGIN_URI
 from qpc.server.login_host import LoginHostCommand
 from qpc.tests_utilities import DEFAULT_CONFIG, HushUpStderr, redirect_stdout
@@ -78,7 +79,8 @@ class LoginCliTests(unittest.TestCase):
             do_mock_raw_input.return_value = 'abc'
             with redirect_stdout(server_out):
                 lhc.main(args)
-                self.assertEqual(server_out.getvalue(), 'Login successful.\n')
+                result = server_out.getvalue().rstrip()
+                self.assertEqual(result, messages.LOGIN_SUCCESS)
 
     @patch('builtins.input')
     @patch('getpass._raw_input')
@@ -95,7 +97,8 @@ class LoginCliTests(unittest.TestCase):
             args = Namespace()
             with redirect_stdout(server_out):
                 lhc.main(args)
-                self.assertEqual(server_out.getvalue(), 'Login successful.\n')
+                result = server_out.getvalue().rstrip()
+                self.assertEqual(result, messages.LOGIN_SUCCESS)
 
     def test_no_prompts_with_args(self):
         """Testing no prompts with args passed."""
@@ -108,4 +111,5 @@ class LoginCliTests(unittest.TestCase):
             args = Namespace(username='admin', password='pass')
             with redirect_stdout(server_out):
                 lhc.main(args)
-                self.assertEqual(server_out.getvalue(), 'Login successful.\n')
+                result = server_out.getvalue().rstrip()
+                self.assertEqual(result, messages.LOGIN_SUCCESS)


### PR DESCRIPTION
closes #145 

---

**How to test:**
```
(qpc) bash-3.2$ qpc server login -h
usage: qpc server login [-h] [--username USERNAME] [--password PASSWORD]
optional arguments:
  -h, --help           show this help message and exit
  --username USERNAME  The user name to log in to the server. If not provided,
                       user will be prompted.
  --password PASSWORD  The password to log in to the server. If not provided,
                       user will be prompted.
(qpc) bash-3.2$ qpc server login
User name: admin
Password:
Login successful.
(qpc) bash-3.2$ qpc server logout
Logged out.
(qpc) bash-3.2$ qpc server login --username admin
Password:
Login successful.
(qpc) bash-3.2$ qpc server logout
Logged out.
(qpc) bash-3.2$ qpc server login --password qpcpassw0rd
User name: admin
Login successful.
(qpc) bash-3.2$ qpc server logout
Logged out.
(qpc) bash-3.2$ qpc server login --password qpcpassw0rd --username admin
Login successful.
```