### PR TITLE
Changes to add --mask flag to report download commands 

### DIFF
--- a/docs/source/man.rst
+++ b/docs/source/man.rst
@@ -503,7 +503,7 @@ Viewing the Details Report
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
 The ``qpc report details`` command retrieves a detailed report that contains the unprocessed facts that are gathered during a scan. These facts are the raw output from Network, vCenter, and Satellite scans, as applicable.
 
-**qpc report details (--scan-job** *scan_job_identifier* **|** **--report** *report_identifier* **)** **(--json|--csv)** **--output-file** *path*
+**qpc report details (--scan-job** *scan_job_identifier* **|** **--report** *report_identifier* **)** **(--json|--csv)** **--output-file** *path* **[--mask]**
 
 ``--scan-job=scan_job_identifier``
 
@@ -525,13 +525,17 @@ The ``qpc report details`` command retrieves a detailed report that contains the
 
   Required. Sets the path to a file location where the report data is saved. The file extension must be ``.json`` for the JSON report or ``.csv`` for the CSV report.
 
+``--mask``
+
+  Displays the results of the report with sensitive data masked by a hash.
+
 Viewing the Deployments Report
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 The ``qpc report deployments`` command retrieves a report that contains the processed fingerprints from a scan. A *fingerprint* is the set of system, product, and entitlement facts for a particular physical or virtual machine. A processed fingerprint results from a procedure that merges facts from various sources, and, when possible, deduplicates redundant systems.
 
 For example, the raw facts of a scan that includes both Network and vCenter sources could show two instances of a machine, indicated by an identical MAC address. The deployments report results in a deduplicated and merged fingerprint that shows both the Network and vCenter facts for that machine as a single set.
 
-**qpc report deployments (--scan-job** *scan_job_identifier* **|** **--report** *report_identifier* **)** **(--json|--csv)** **--output-file** *path*
+**qpc report deployments (--scan-job** *scan_job_identifier* **|** **--report** *report_identifier* **)** **(--json|--csv)** **--output-file** *path* **[--mask]**
 
 ``--scan-job=scan_job_identifier``
 
@@ -552,6 +556,10 @@ For example, the raw facts of a scan that includes both Network and vCenter sour
 ``--output-file=path``
 
   Required. Sets the path to a file location where the report data is saved.  The file extension must be ``.json`` for the JSON report or ``.csv`` for the CSV report.
+
+``--mask``
+
+  Displays the results of the report with sensitive data masked by a hash.
 
 Viewing the Insights Report
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -576,7 +584,7 @@ Downloading Reports
 ~~~~~~~~~~~~~~~~~~~
 The ``qpc report download`` command downloads a set of reports, identified either by scan job identifer or report identifier, as a TAR.GZ file.  The report TAR.GZ file contains the details and deployments reports in both their JSON and CSV formats.
 
-**qpc report download (--scan-job** *scan_job_identifier* **|** **--report** *report_identifier* **)** **--output-file** *path*
+**qpc report download (--scan-job** *scan_job_identifier* **|** **--report** *report_identifier* **)** **--output-file** *path* **[--mask]**
 
 ``--scan-job=scan_job_identifier``
 
@@ -589,6 +597,10 @@ The ``qpc report download`` command downloads a set of reports, identified eithe
 ``--output-file=path``
 
   Required. Sets the path to a file location where the report data is saved. The file extension must be ``.tar.gz``.
+
+``--mask``
+
+  Download the reports with sensitive data masked by a hash.
 
 Merging Scan Job Results
 ~~~~~~~~~~~~~~~~~~~~~~~~

--- a/qpc.spec
+++ b/qpc.spec
@@ -70,6 +70,7 @@ install -D -p -m 644 docs/qpc.1 $RPM_BUILD_ROOT%{_mandir}/man1/qpc.1
 * Thu Nov 14 2019 Kevan Holdaway <kholdawa@redhat.com> 0.9.3-1
 - Bump version to 0.9.3 for master branch. <kholdawa@redhat.com>
 - Added password arg to server login. <cmyers@redhat.com>
+- Expose endpoint to upload a details report. <kholdawa@redhat.com>
 - Added --mask flag to mask sensitive data in reports. <aaiken@redhat.com>
 * Thu Nov 14 2019 Ashley Aiken <aaiken@redhat.com> 0.9.2-1
 - Bump version to 0.9.2 for master branch

--- a/qpc.spec
+++ b/qpc.spec
@@ -70,6 +70,7 @@ install -D -p -m 644 docs/qpc.1 $RPM_BUILD_ROOT%{_mandir}/man1/qpc.1
 * Thu Nov 14 2019 Kevan Holdaway <kholdawa@redhat.com> 0.9.3-1
 - Bump version to 0.9.3 for master branch. <kholdawa@redhat.com>
 - Added password arg to server login. <cmyers@redhat.com>
+- Added --mask flag to mask sensitive data in reports. <aaiken@redhat.com>
 * Thu Nov 14 2019 Ashley Aiken <aaiken@redhat.com> 0.9.2-1
 - Bump version to 0.9.2 for master branch
 - Dependency version updates

--- a/qpc/messages.py
+++ b/qpc/messages.py
@@ -194,8 +194,12 @@ REPORT_SJ_DOES_NOT_EXIST = \
 REPORT_SJS_DO_NOT_EXIST = 'The following scan jobs do not exist: %s.'
 REPORT_NO_DEPLOYMENTS_REPORT_FOR_SJ = \
     'No deployments report available for scan job %s.'
+REPORT_COULD_NOT_BE_MASKED_SJ = 'The deployments report could not be '\
+    'masked for scan job %s. To generate a masked report, rerun the scan.'
 REPORT_NO_DEPLOYMENTS_REPORT_FOR_REPORT_ID = \
     'Deployments report %s does not exist.'
+REPORT_COULD_NOT_BE_MASKED_REPORT_ID = 'Deployments report %s could not be '\
+    'masked. To generate a masked report, rerun the scan.'
 REPORT_NO_DETAIL_REPORT_FOR_SJ = \
     'No report detail available for scan job %s.'
 REPORT_NO_DETAIL_REPORT_FOR_REPORT_ID = \
@@ -321,6 +325,8 @@ INSIGHTS_REQUIRE_SUDO = 'Insights upload command requires sudo access.'
 INSIGHTS_NO_GPG_HELP = 'Upload to Insights without GNU Privacy Guard.'
 DOWNLOAD_NO_REPORT_FOR_SJ = 'No reports available for scan job %s.'
 DOWNLOAD_NO_REPORT_FOUND = 'Report %s not found.'
+DOWNLOAD_NO_MASK_REPORT = 'Report %s could not be masked. To generate a '\
+    'masked report, rerun the scan.'
 DOWNLOAD_PATH_HELP = "The output file's name and location. This file is " \
     'required to be a tar.gz'
 DOWNLOAD_SUCCESSFULLY_WRITTEN = 'Report %s successfully written to %s.'

--- a/qpc/messages.py
+++ b/qpc/messages.py
@@ -220,6 +220,8 @@ REPORT_UPLOAD_JSON_FILE_HELP = 'The path to the details report JSON file.'
 REPORT_UPLOAD_VALIDATE_JSON = 'Checking %s for valid JSON details report.'
 REPORT_SUCCESSFULLY_UPLOADED = 'Report %s created.'
 REPORT_FAILED_TO_UPLOADED = 'Report could not be created.  Error: %s'
+REPORT_MASK_HELP = 'Provide this flag in order to mask the sensitive data '\
+    'within the report(s).'
 DISABLE_OPT_PRODUCTS_HELP = 'The product inspection exclusions. '\
     'Contains the list of products to exclude from inspection. '\
     'Valid values: jboss_eap, jboss_fuse, jboss_brms, jboss_ws.'

--- a/qpc/messages.py
+++ b/qpc/messages.py
@@ -197,8 +197,8 @@ REPORT_NO_DEPLOYMENTS_REPORT_FOR_SJ = \
 REPORT_COULD_NOT_BE_MASKED_SJ = 'The deployments report could not be '\
     'masked for scan job %s. To generate a masked report, rerun the scan.'
 REPORT_NO_DEPLOYMENTS_REPORT_FOR_REPORT_ID = \
-    'Deployments report %s does not exist.'
-REPORT_COULD_NOT_BE_MASKED_REPORT_ID = 'Deployments report %s could not be '\
+    'The deployments report %s does not exist.'
+REPORT_COULD_NOT_BE_MASKED_REPORT_ID = 'The deployments report %s could not be '\
     'masked. To generate a masked report, rerun the scan.'
 REPORT_NO_DETAIL_REPORT_FOR_SJ = \
     'No report detail available for scan job %s.'

--- a/qpc/report/deployments.py
+++ b/qpc/report/deployments.py
@@ -60,6 +60,8 @@ class ReportDeploymentsCommand(CliCommand):
         self.parser.add_argument('--output-file', dest='path', metavar='PATH',
                                  help=_(messages.REPORT_PATH_HELP),
                                  required=True)
+        self.parser.add_argument('--mask', dest='mask', action='store_true',
+                                 help=_(messages.REPORT_MASK_HELP), required=False)
         self.report_id = None
 
     def _validate_args(self):
@@ -71,6 +73,8 @@ class ReportDeploymentsCommand(CliCommand):
         if self.args.output_csv:
             extension = '.csv'
             self.req_headers = {'Accept': 'text/csv'}
+        if self.args.mask:
+            self.req_params = {'mask': True}
         if extension:
             check_extension(extension, self.args.path)
 

--- a/qpc/report/deployments.py
+++ b/qpc/report/deployments.py
@@ -63,6 +63,7 @@ class ReportDeploymentsCommand(CliCommand):
         self.parser.add_argument('--mask', dest='mask', action='store_true',
                                  help=_(messages.REPORT_MASK_HELP), required=False)
         self.report_id = None
+        self.min_server_version = '0.9.2'
 
     def _validate_args(self):
         CliCommand._validate_args(self)
@@ -128,9 +129,17 @@ class ReportDeploymentsCommand(CliCommand):
 
     def _handle_response_error(self):
         if self.args.report_id is None:
-            print(_(messages.REPORT_NO_DEPLOYMENTS_REPORT_FOR_SJ %
-                    self.args.scan_job_id))
+            if self.response.status_code == 428:
+                print(_(messages.REPORT_COULD_NOT_BE_MASKED_SJ) %
+                      self.args.scan_job_id)
+            else:
+                print(_(messages.REPORT_NO_DEPLOYMENTS_REPORT_FOR_SJ %
+                        self.args.scan_job_id))
         else:
-            print(_(messages.REPORT_NO_DEPLOYMENTS_REPORT_FOR_REPORT_ID %
-                    self.args.report_id))
+            if self.response.status_code == 428:
+                print(_(messages.REPORT_COULD_NOT_BE_MASKED_REPORT_ID %
+                        self.args.report_id))
+            else:
+                print(_(messages.REPORT_NO_DEPLOYMENTS_REPORT_FOR_REPORT_ID %
+                        self.args.report_id))
         sys.exit(1)

--- a/qpc/report/details.py
+++ b/qpc/report/details.py
@@ -60,6 +60,8 @@ class ReportDetailsCommand(CliCommand):
         self.parser.add_argument('--output-file', dest='path', metavar='PATH',
                                  help=_(messages.REPORT_PATH_HELP),
                                  required=True)
+        self.parser.add_argument('--mask', dest='mask', action='store_true',
+                                 help=_(messages.REPORT_MASK_HELP), required=False)
         self.report_id = None
 
     def _validate_args(self):
@@ -71,6 +73,8 @@ class ReportDetailsCommand(CliCommand):
         if self.args.output_csv:
             extension = '.csv'
             self.req_headers = {'Accept': 'text/csv'}
+        if self.args.mask:
+            self.req_params = {'mask': True}
         if extension:
             check_extension(extension, self.args.path)
         try:

--- a/qpc/report/details.py
+++ b/qpc/report/details.py
@@ -63,6 +63,7 @@ class ReportDetailsCommand(CliCommand):
         self.parser.add_argument('--mask', dest='mask', action='store_true',
                                  help=_(messages.REPORT_MASK_HELP), required=False)
         self.report_id = None
+        self.min_server_version = '0.9.2'
 
     def _validate_args(self):
         CliCommand._validate_args(self)

--- a/qpc/report/download.py
+++ b/qpc/report/download.py
@@ -52,11 +52,15 @@ class ReportDownloadCommand(CliCommand):
         self.parser.add_argument('--output-file', dest='path', metavar='PATH',
                                  help=_(messages.DOWNLOAD_PATH_HELP),
                                  required=True)
+        self.parser.add_argument('--mask', dest='mask', action='store_true',
+                                 help=_(messages.REPORT_MASK_HELP), required=False)
         self.min_server_version = '0.0.46'
         self.report_id = None
 
     def _validate_args(self):
         self.req_headers = {'Accept': 'application/gzip'}
+        if self.args.mask:
+            self.req_params = {'mask': True}
         try:
             validate_write_file(self.args.path, 'output-file')
         except ValueError as error:

--- a/qpc/report/download.py
+++ b/qpc/report/download.py
@@ -54,7 +54,7 @@ class ReportDownloadCommand(CliCommand):
                                  required=True)
         self.parser.add_argument('--mask', dest='mask', action='store_true',
                                  help=_(messages.REPORT_MASK_HELP), required=False)
-        self.min_server_version = '0.0.46'
+        self.min_server_version = '0.9.2'
         self.report_id = None
 
     def _validate_args(self):
@@ -103,6 +103,10 @@ class ReportDownloadCommand(CliCommand):
             sys.exit(1)
 
     def _handle_response_error(self):
-        print(_(messages.DOWNLOAD_NO_REPORT_FOUND %
-                self.args.report_id))
+        if self.response.status_code == 428:
+            print(_(messages.DOWNLOAD_NO_MASK_REPORT) %
+                  self.args.report_id)
+        else:
+            print(_(messages.DOWNLOAD_NO_REPORT_FOUND %
+                    self.args.report_id))
         sys.exit(1)

--- a/qpc/report/tests_report_details.py
+++ b/qpc/report/tests_report_details.py
@@ -83,7 +83,8 @@ class ReportDetailsTests(unittest.TestCase):
                              report_id=None,
                              output_json=True,
                              output_csv=False,
-                             path=self.test_json_filename)
+                             path=self.test_json_filename,
+                             mask=False)
             with redirect_stdout(report_out):
                 nac.main(args)
                 self.assertEqual(report_out.getvalue().strip(),
@@ -111,7 +112,8 @@ class ReportDetailsTests(unittest.TestCase):
                              report_id='1',
                              output_json=True,
                              output_csv=False,
-                             path=self.test_json_filename)
+                             path=self.test_json_filename,
+                             mask=False)
             with redirect_stdout(report_out):
                 nac.main(args)
                 self.assertEqual(report_out.getvalue().strip(),
@@ -145,7 +147,8 @@ class ReportDetailsTests(unittest.TestCase):
                              report_id=None,
                              output_json=False,
                              output_csv=True,
-                             path=self.test_csv_filename)
+                             path=self.test_csv_filename,
+                             mask=False)
             with redirect_stdout(report_out):
                 nac.main(args)
                 self.assertEqual(report_out.getvalue().strip(),
@@ -193,7 +196,8 @@ class ReportDetailsTests(unittest.TestCase):
                              report_id=None,
                              output_json=True,
                              output_csv=False,
-                             path=self.test_json_filename)
+                             path=self.test_json_filename,
+                             mask=False)
             with self.assertRaises(SystemExit):
                 with redirect_stdout(report_out):
                     nac.main(args)
@@ -215,7 +219,8 @@ class ReportDetailsTests(unittest.TestCase):
                              report_id=None,
                              output_json=True,
                              output_csv=False,
-                             path=self.test_json_filename)
+                             path=self.test_json_filename,
+                             mask=False)
             with self.assertRaises(SystemExit):
                 with redirect_stdout(report_out):
                     nac.main(args)
@@ -241,7 +246,8 @@ class ReportDetailsTests(unittest.TestCase):
                              report_id='1',
                              output_json=True,
                              output_csv=False,
-                             path=self.test_json_filename)
+                             path=self.test_json_filename,
+                             mask=False)
             with redirect_stdout(report_out):
                 with self.assertRaises(SystemExit):
                     nac.main(args)
@@ -267,7 +273,8 @@ class ReportDetailsTests(unittest.TestCase):
                              report_id='1',
                              output_json=True,
                              output_csv=False,
-                             path=fake_dir)
+                             path=fake_dir,
+                             mask=False)
             with redirect_stdout(report_out):
                 with self.assertRaises(SystemExit):
                     nac.main(args)
@@ -293,7 +300,8 @@ class ReportDetailsTests(unittest.TestCase):
                              report_id='1',
                              output_json=True,
                              output_csv=False,
-                             path=non_json_dir)
+                             path=non_json_dir,
+                             mask=False)
             with redirect_stdout(report_out):
                 with self.assertRaises(SystemExit):
                     nac.main(args)
@@ -318,7 +326,8 @@ class ReportDetailsTests(unittest.TestCase):
                              report_id='1',
                              output_json=False,
                              output_csv=True,
-                             path=non_csv_dir)
+                             path=non_csv_dir,
+                             mask=False)
             with redirect_stdout(report_out):
                 with self.assertRaises(SystemExit):
                     nac.main(args)
@@ -339,7 +348,8 @@ class ReportDetailsTests(unittest.TestCase):
                              report_id='1',
                              output_json=True,
                              output_csv=False,
-                             path=self.test_json_filename)
+                             path=self.test_json_filename,
+                             mask=False)
             with redirect_stdout(report_out):
                 with self.assertRaises(SystemExit):
                     nac.main(args)
@@ -370,10 +380,47 @@ class ReportDetailsTests(unittest.TestCase):
                              report_id=None,
                              output_json=True,
                              output_csv=False,
-                             path=self.test_json_filename)
+                             path=self.test_json_filename,
+                             mask=False)
             with redirect_stdout(report_out):
                 with self.assertRaises(SystemExit):
                     nac.main(args)
                 self.assertEqual(report_out.getvalue().strip(),
                                  messages.REPORT_NO_DETAIL_REPORT_FOR_SJ
                                  % 1)
+
+    def test_detail_report_as_csv_masked(self):
+        """Testing retreiving csv details report with masked query param."""
+        report_out = StringIO()
+        get_scanjob_url = get_server_location() + \
+            SCAN_JOB_URI + '1'
+        get_scanjob_json_data = {'id': 1, 'report_id': 1}
+        get_report_url = get_server_location() + \
+            REPORT_URI + '1/details/' + '?mask=True'
+        get_report_csv_data = 'Report\n'
+        get_report_csv_data += '1\n\n\n'
+        get_report_csv_data += 'key\n'
+        get_report_csv_data += 'value\n'
+
+        get_report_csv_data = {'id': 1, 'report': [{'key': 'value'}]}
+        with requests_mock.Mocker() as mocker:
+            mocker.get(get_scanjob_url, status_code=200,
+                       json=get_scanjob_json_data)
+            mocker.get(get_report_url, status_code=200,
+                       json=get_report_csv_data)
+            nac = ReportDetailsCommand(SUBPARSER)
+            args = Namespace(scan_job_id='1',
+                             report_id=None,
+                             output_json=False,
+                             output_csv=True,
+                             path=self.test_csv_filename,
+                             mask=True)
+            with redirect_stdout(report_out):
+                nac.main(args)
+                self.assertEqual(report_out.getvalue().strip(),
+                                 messages.REPORT_SUCCESSFULLY_WRITTEN)
+                with open(self.test_csv_filename, 'r') as json_file:
+                    data = json_file.read()
+                    file_content_dict = json.loads(data)
+                    print(file_content_dict)
+                self.assertDictEqual(get_report_csv_data, file_content_dict)

--- a/qpc/report/tests_report_download.py
+++ b/qpc/report/tests_report_download.py
@@ -274,7 +274,7 @@ class ReportDownloadTests(unittest.TestCase):
                     nac.main(args)
                 self.assertEqual(report_out.getvalue().strip(),
                                  messages.SERVER_TOO_OLD_FOR_CLI %
-                                 ('0.0.46', '0.0.46', '0.0.45'))
+                                 ('0.9.2', '0.9.2', '0.0.45'))
 
     def test_download_bad_file_extension(self):
         """Test download with bad file extension."""
@@ -323,3 +323,24 @@ class ReportDownloadTests(unittest.TestCase):
                 self.assertEqual(report_out.getvalue().strip(),
                                  messages.DOWNLOAD_SUCCESSFULLY_WRITTEN %
                                  ('1', self.test_tar_filename))
+
+    def test_download_report_id_428(self):
+        """Test download with nonexistent report id."""
+        report_out = StringIO()
+        get_report_url = get_server_location() + \
+            REPORT_URI + '1'
+        get_report_json_data = {'id': 1, 'report': [{'key': 'value'}]}
+        with requests_mock.Mocker() as mocker:
+            mocker.get(get_report_url, status_code=428,
+                       headers={'X-Server-Version': VERSION},
+                       json=get_report_json_data)
+            nac = ReportDownloadCommand(SUBPARSER)
+            args = Namespace(scan_job_id=None,
+                             report_id='1',
+                             path=self.test_tar_filename,
+                             mask=False)
+            with redirect_stdout(report_out):
+                with self.assertRaises(SystemExit):
+                    nac.main(args)
+                self.assertEqual(report_out.getvalue().strip(),
+                                 messages.DOWNLOAD_NO_MASK_REPORT % 1)

--- a/qpc/report/tests_report_download.py
+++ b/qpc/report/tests_report_download.py
@@ -80,7 +80,8 @@ class ReportDownloadTests(unittest.TestCase):
             nac = ReportDownloadCommand(SUBPARSER)
             args = Namespace(scan_job_id='1',
                              report_id=None,
-                             path=self.test_tar_filename)
+                             path=self.test_tar_filename,
+                             mask=False)
             with redirect_stdout(report_out):
                 nac.main(args)
                 self.assertEqual(report_out.getvalue().strip(),
@@ -103,7 +104,8 @@ class ReportDownloadTests(unittest.TestCase):
             nac = ReportDownloadCommand(SUBPARSER)
             args = Namespace(scan_job_id=None,
                              report_id='1',
-                             path=self.test_tar_filename)
+                             path=self.test_tar_filename,
+                             mask=False)
             with redirect_stdout(report_out):
                 nac.main(args)
                 self.assertEqual(report_out.getvalue().strip(),
@@ -150,7 +152,8 @@ class ReportDownloadTests(unittest.TestCase):
             nac = ReportDownloadCommand(SUBPARSER)
             args = Namespace(scan_job_id='1',
                              report_id=None,
-                             path=self.test_tar_filename)
+                             path=self.test_tar_filename,
+                             mask=False)
             with redirect_stdout(report_out):
                 with self.assertRaises(SystemExit):
                     nac.main(args)
@@ -169,7 +172,8 @@ class ReportDownloadTests(unittest.TestCase):
             nac = ReportDownloadCommand(SUBPARSER)
             args = Namespace(scan_job_id='1',
                              report_id=None,
-                             path=self.test_tar_filename)
+                             path=self.test_tar_filename,
+                             mask=False)
             with redirect_stdout(report_out):
                 with self.assertRaises(SystemExit):
                     nac.main(args)
@@ -192,7 +196,8 @@ class ReportDownloadTests(unittest.TestCase):
             nac = ReportDownloadCommand(SUBPARSER)
             args = Namespace(scan_job_id=None,
                              report_id='1',
-                             path=fake_dir)
+                             path=fake_dir,
+                             mask=False)
             with redirect_stdout(report_out):
                 with self.assertRaises(SystemExit):
                     nac.main(args)
@@ -219,7 +224,8 @@ class ReportDownloadTests(unittest.TestCase):
             nac = ReportDownloadCommand(SUBPARSER)
             args = Namespace(scan_job_id=None,
                              report_id='1',
-                             path=self.test_tar_filename)
+                             path=self.test_tar_filename,
+                             mask=False)
             with redirect_stdout(report_out):
                 with self.assertRaises(SystemExit):
                     nac.main(args)
@@ -240,7 +246,8 @@ class ReportDownloadTests(unittest.TestCase):
             nac = ReportDownloadCommand(SUBPARSER)
             args = Namespace(scan_job_id=None,
                              report_id=1,
-                             path=self.test_tar_filename)
+                             path=self.test_tar_filename,
+                             mask=False)
             with redirect_stdout(report_out):
                 with self.assertRaises(SystemExit):
                     nac.main(args)
@@ -260,7 +267,8 @@ class ReportDownloadTests(unittest.TestCase):
             nac = ReportDownloadCommand(SUBPARSER)
             args = Namespace(scan_job_id=None,
                              report_id=1,
-                             path=self.test_tar_filename)
+                             path=self.test_tar_filename,
+                             mask=False)
             with redirect_stdout(report_out):
                 with self.assertRaises(SystemExit):
                     nac.main(args)
@@ -284,9 +292,34 @@ class ReportDownloadTests(unittest.TestCase):
             nac = ReportDownloadCommand(SUBPARSER)
             args = Namespace(scan_job_id=None,
                              report_id='1',
-                             path='test.json')
+                             path='test.json',
+                             mask=False)
             with redirect_stdout(report_out):
                 with self.assertRaises(SystemExit):
                     nac.main(args)
                 self.assertEqual(report_out.getvalue().strip(),
                                  messages.OUTPUT_FILE_TYPE % 'tar.gz')
+
+    def test_download_report_id_masked(self):
+        """Testing download with report id and mask set to true."""
+        report_out = StringIO()
+        get_report_url = get_server_location() + \
+            REPORT_URI + '1' + '?mask=True'
+        get_report_json_data = {'id': 1, 'report': [{'key': 'value'}]}
+        test_dict = dict()
+        test_dict[self.test_tar_filename] = get_report_json_data
+        buffer_content = create_tar_buffer(test_dict)
+        with requests_mock.Mocker() as mocker:
+            mocker.get(get_report_url, status_code=200,
+                       headers={'X-Server-Version': VERSION},
+                       content=buffer_content)
+            nac = ReportDownloadCommand(SUBPARSER)
+            args = Namespace(scan_job_id=None,
+                             report_id='1',
+                             path=self.test_tar_filename,
+                             mask=True)
+            with redirect_stdout(report_out):
+                nac.main(args)
+                self.assertEqual(report_out.getvalue().strip(),
+                                 messages.DOWNLOAD_SUCCESSFULLY_WRITTEN %
+                                 ('1', self.test_tar_filename))

--- a/qpc/utils.py
+++ b/qpc/utils.py
@@ -42,7 +42,7 @@ CONFIG_REQUIRE_TOKEN = 'require_token'
 
 LOG_LEVEL_INFO = 0
 
-QPC_MIN_SERVER_VERSION = '0.0.46'
+QPC_MIN_SERVER_VERSION = '0.9.0'
 
 # pylint: disable=invalid-name
 logging.captureWarnings(True)


### PR DESCRIPTION
Closes #152 
`qpc report details`, `qpc report deployments` and `qpc report download` now all have a `--mask` option. 