### PR TITLE
Fix a bug on json_dir treatment

### DIFF
--- a/qpc/report/merge.py
+++ b/qpc/report/merge.py
@@ -134,7 +134,9 @@ class ReportMergeCommand(CliCommand):
 
         :returns Json containing the sources of each file.
         """
-        path = self.args.json_dir[0]
+        path = self.args.json_dir
+        if isinstance(path, list):
+            path = path[0]
         if os.path.isdir(path) is not True:
             print(_(messages.REPORT_JSON_DIR_NOT_FOUND % path))
             sys.exit(1)


### PR DESCRIPTION
Example of the problem here:
https://github.com/quipucords/qpc/runs/7438213333?check_suite_focus=true#step:5:242

if json_dir is not a list it will pick the first letter of the path, which would be the root dir (`/`).