### PR TITLE
Remove insights upload from cli commands

### DIFF
--- a/qpc/cli.py
+++ b/qpc/cli.py
@@ -28,7 +28,6 @@ from qpc.insights.commands import (
     InsightsAddLoginCommand,
     InsightsConfigureCommand,
     InsightsPublishCommand,
-    InsightsUploadCommand,
 )
 from qpc.release import PKG_NAME, VERSION
 from qpc.report.commands import (
@@ -143,7 +142,6 @@ class CLI():
             insights.SUBCOMMAND,
             [
                 InsightsConfigureCommand,
-                InsightsUploadCommand,
                 InsightsAddLoginCommand,
                 InsightsPublishCommand,
             ],

--- a/qpc/insights/tests_insights_upload.py
+++ b/qpc/insights/tests_insights_upload.py
@@ -37,6 +37,10 @@ SUBPARSER = PARSER.add_subparsers(dest='subcommand')
 
 
 # pylint: disable=too-many-public-methods,protected-access
+@unittest.skip(
+    "Upload subcommand is temporarily disable to "
+    "prevent user's confusion with the publish command."
+)
 class InsightsUploadCliTests(unittest.TestCase):
     """Class for testing the scan job commands for qpc."""
 


### PR DESCRIPTION
Removal is neccessary to simplify things for the end user, who might confuse the upload and publish subcommands.
Code was not completely removed, in case we need it in the future.