### PR TITLE
Feature/verbosity control

### DIFF
--- a/qpc/insights/publish.py
+++ b/qpc/insights/publish.py
@@ -163,6 +163,7 @@ class InsightsPublishCommand(CliCommand):
         log.info(_(messages.INSIGHTS_PUBLISH_RESPONSE), response.text)
         if response.ok:
             log.info(_(messages.INSIGHTS_PUBLISH_SUCCESSFUL))
+            print(response.text)
         elif response.status_code == 401:
             log.error(_(messages.INSIGHTS_PUBLISH_AUTH_ERROR))
         elif response.status_code == 404:

--- a/qpc/utils.py
+++ b/qpc/utils.py
@@ -19,6 +19,7 @@ import logging
 import os
 import sys
 import tarfile
+from collections import defaultdict
 
 from cryptography.fernet import Fernet, InvalidToken
 
@@ -333,15 +334,18 @@ def setup_logging(verbosity):
     Must be run after ensure_data_dir_exists().
 
     :param verbosity: verbosity level, as measured in -v's on the command line.
-        Can be None for default.
+        Should be an integer.
     """
+    # using default dict so any value (supposedly) higher than 1 will map to DEBUG
+    # e.g calling qpc -vv would be the same as qpc -vvvvvvvvvvv
+    verbosity_map = defaultdict(
+        lambda: logging.DEBUG,
+        {0: logging.ERROR, 1: logging.INFO},
+    )
+    log_level = verbosity_map[verbosity]
     log_prefix = "%(asctime)s - %(name)s - %(levelname)s"
-
-    if verbosity == LOG_LEVEL_INFO:
-        log_level = logging.INFO
-    else:
-        log_level = logging.DEBUG
-        log_prefix += "- %(funcName)s:%(lineno)d"
+    if log_level == logging.DEBUG:
+        log_prefix += " - [%(funcName)s] - %(pathname)s:%(lineno)d"
 
     log_fmt = f"{log_prefix} - %(message)s"
     # Using basicConfig here means that all log messages, even

--- a/qpc/utils.py
+++ b/qpc/utils.py
@@ -379,7 +379,7 @@ def log_args(args):
     :param args: the arguments provided to the qpc command
     """
     message = 'Args: "%s"'
-    log.info(message, args)
+    log.debug(message, args)
 
 
 def handle_error_response(response):


### PR DESCRIPTION
Restore the default behaviour for streamlogger: send only ERROR logs. The verbosity of logs can be increased with the `-v` flag.

Some usage examples:

```
$ qpc scan list
[
    {
        "id": 1,
        "name": "scan-target",
        "options": {
            "max_concurrency": 25
        },
        "scan_type": "inspect",
        "sources": [
            {
                "id": 1,
                "name": "scan-target",
                "source_type": "network"
            }
        ]
    }
]
```

```
$ qpc -v scan list                                                                                                                 [13:41:46]
2022-07-29 13:41:50,691 - qpc - INFO - Method: "GET", Command: "qpc scan list", URL: "https://localhost:9443/api/v1/scans/", Response: "{'count': 1, 'next': None, 'previous': None, 'results': [{'id': 1, 'name': 'scan-target', 'sources': [{'id': 1, 'name': 'scan-target', 'source_type': 'network'}], 'scan_type': 'inspect', 'options': {'max_concurrency': 25}}]}", Status Code: "200
[
    {
        "id": 1,
        "name": "scan-target",
        "options": {
            "max_concurrency": 25
        },
        "scan_type": "inspect",
        "sources": [
            {
                "id": 1,
                "name": "scan-target",
                "source_type": "network"
            }
        ]
    }
]
```

```
$ qpc -vv scan list
2022-07-29 13:42:10,089 - qpc - DEBUG - [log_args] - /home/bciconel/SourceCode/qpc/qpc/utils.py:382 - Args: "Namespace(verbosity=2, subcommand='scan', action='list', type=None)"
2022-07-29 13:42:10,120 - qpc - INFO - [log_request_info] - /home/bciconel/SourceCode/qpc/qpc/utils.py:372 - Method: "GET", Command: "qpc scan list", URL: "https://localhost:9443/api/v1/scans/", Response: "{'count': 1, 'next': None, 'previous': None, 'results': [{'id': 1, 'name': 'scan-target', 'sources': [{'id': 1, 'name': 'scan-target', 'source_type': 'network'}], 'scan_type': 'inspect', 'options': {'max_concurrency': 25}}]}", Status Code: "200
[
    {
        "id": 1,
        "name": "scan-target",
        "options": {
            "max_concurrency": 25
        },
        "scan_type": "inspect",
        "sources": [
            {
                "id": 1,
                "name": "scan-target",
                "source_type": "network"
            }
        ]
    }
]
```