### PR TITLE
Feature/combine insights download publish

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -541,6 +541,20 @@ python-versions = "*"
 pytest = ">=3.2.5"
 
 [[package]]
+name = "pytest-mock"
+version = "3.8.2"
+description = "Thin-wrapper around the mock package for easier use with pytest"
+category = "dev"
+optional = false
+python-versions = ">=3.7"
+
+[package.dependencies]
+pytest = ">=5.0"
+
+[package.extras]
+dev = ["pre-commit", "pytest-asyncio", "tox"]
+
+[[package]]
 name = "requests"
 version = "2.28.1"
 description = "Python HTTP for Humans."
@@ -635,7 +649,7 @@ virtualenv = ">=16.0.0,<20.0.0 || >20.0.0,<20.0.1 || >20.0.1,<20.0.2 || >20.0.2,
 
 [package.extras]
 docs = ["pygments-github-lexers (>=0.0.5)", "sphinx (>=2.0.0)", "sphinxcontrib-autoprogram (>=0.1.5)", "towncrier (>=18.5.0)"]
-testing = ["flaky (>=3.4.0)", "freezegun (>=0.3.11)", "pytest (>=4.0.0)", "pytest-cov (>=2.5.1)", "pytest-mock (>=1.10.0)", "pytest-randomly (>=1.0.0)", "psutil (>=5.6.1)", "pathlib2 (>=2.3.3)"]
+testing = ["flaky (>=3.4.0)", "freezegun (>=0.3.11)", "pathlib2 (>=2.3.3)", "psutil (>=5.6.1)", "pytest (>=4.0.0)", "pytest-cov (>=2.5.1)", "pytest-mock (>=1.10.0)", "pytest-randomly (>=1.0.0)"]
 
 [[package]]
 name = "tox-poetry"
@@ -717,13 +731,13 @@ optional = false
 python-versions = ">=3.7"
 
 [package.extras]
-docs = ["sphinx", "jaraco.packaging (>=9)", "rst.linker (>=1.9)", "jaraco.tidelift (>=1.4)"]
-testing = ["pytest (>=6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytest-cov", "pytest-enabler (>=1.3)", "jaraco.itertools", "func-timeout", "pytest-black (>=0.3.7)", "pytest-mypy (>=0.9.1)"]
+docs = ["jaraco.packaging (>=9)", "jaraco.tidelift (>=1.4)", "rst.linker (>=1.9)", "sphinx"]
+testing = ["func-timeout", "jaraco.itertools", "pytest (>=6)", "pytest-black (>=0.3.7)", "pytest-checkdocs (>=2.4)", "pytest-cov", "pytest-enabler (>=1.3)", "pytest-flake8", "pytest-mypy (>=0.9.1)"]
 
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.7"
-content-hash = "5dd8e07a166b72084333cdb900444e7be7f3d2e168dbe2c174832331c1f0ad8c"
+content-hash = "69c789acd9d289c1f3093cf0ab45326b785c260c1c457c94a3c5e29c63c88010"
 
 [metadata.files]
 astroid = [
@@ -1073,6 +1087,10 @@ pytest-cov = [
 pytest-lazy-fixture = [
     {file = "pytest-lazy-fixture-0.6.3.tar.gz", hash = "sha256:0e7d0c7f74ba33e6e80905e9bfd81f9d15ef9a790de97993e34213deb5ad10ac"},
     {file = "pytest_lazy_fixture-0.6.3-py3-none-any.whl", hash = "sha256:e0b379f38299ff27a653f03eaa69b08a6fd4484e46fd1c9907d984b9f9daeda6"},
+]
+pytest-mock = [
+    {file = "pytest-mock-3.8.2.tar.gz", hash = "sha256:77f03f4554392558700295e05aed0b1096a20d4a60a4f3ddcde58b0c31c8fca2"},
+    {file = "pytest_mock-3.8.2-py3-none-any.whl", hash = "sha256:8a9e226d6c0ef09fcf20c94eb3405c388af438a90f3e39687f84166da82d5948"},
 ]
 requests = [
     {file = "requests-2.28.1-py3-none-any.whl", hash = "sha256:8fefa2a1a1365bf5520aac41836fbee479da67864514bdb821f31ce07ce65349"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,6 +38,7 @@ pytest-lazy-fixture = ">=0.6.3"
 requests-mock = ">=1.9.3"
 tox = ">=3.25.1"
 tox-poetry = ">=0.4.1"
+pytest-mock = "^3.8.2"
 
 [build-system]
 requires = ["poetry-core>=1.0.0"]

--- a/qpc/clicommand.py
+++ b/qpc/clicommand.py
@@ -57,9 +57,9 @@ class CliCommand():
         """Sub-commands can define to construct request payload."""
         pass
 
-    def _handle_response_error(self):
+    def _handle_response_error(self, response=None):
         """Sub-commands can override this method to perform error handling."""
-        handle_error_response(self.response)
+        handle_error_response(response or self.response)
         sys.exit(1)
 
     def _handle_response_success(self):

--- a/qpc/insights/tests_insights_publish.py
+++ b/qpc/insights/tests_insights_publish.py
@@ -18,7 +18,8 @@ import pytest
 
 from qpc import messages
 from qpc.cli import CLI
-from qpc.insights import INGRESS_REPORT_URI
+from qpc.insights import INGRESS_REPORT_URI, INSIGHTS_PATH_SUFFIX, REPORT_URI
+from qpc.insights.publish import InsightsPublishCommand
 from qpc.utils import write_server_config
 
 
@@ -139,11 +140,30 @@ def non_tarball_payload(tmp_path):
 class TestInsightsPublishCommand:
     """Class for testing insights publish command."""
 
-    def test_insight_login_req_args_err(self):
+    def test_insights_publish_req_args_err(self):
         """Testing if insights publish command requires args."""
         sys.argv = ["/bin/qpc", "insights", "publish"]
         with pytest.raises(SystemExit):
             CLI().main()
+
+    def test_insights_publish_args_are_mutually_exclusive(self, mocker):
+        """Testing if insights publish command args are mutually exclusive."""
+        mocker.patch.object(
+            InsightsPublishCommand, "_publish_to_ingress", side_effect=RuntimeError()
+        )
+        sys.argv = [
+            "/bin/qpc",
+            "insights",
+            "publish",
+            "--input-file",
+            "file_example",
+            "--report",
+            "1",
+        ]
+        with pytest.raises(SystemExit) as exc_info:
+            CLI().main()
+        # argparse will always exit with value 2
+        assert exc_info.value.code == 2
 
     def test_validate_report_name_if_invalid_name(
         self,
@@ -204,6 +224,7 @@ class TestInsightsPublishCommand:
         ]
         CLI().main()
         assert caplog.messages[-1] == messages.INSIGHTS_PUBLISH_SUCCESSFUL
+        assert payload_file.exists(), "Input file should not be removed."
 
     @pytest.mark.parametrize(
         "status_code,log_message",
@@ -239,6 +260,7 @@ class TestInsightsPublishCommand:
         with pytest.raises(SystemExit):
             CLI().main()
         assert caplog.messages[-1] == log_message
+        assert payload_file.exists(), "Input file should not be removed."
 
     @pytest.mark.parametrize(
         "payload,log_message",
@@ -278,3 +300,104 @@ class TestInsightsPublishCommand:
         with pytest.raises(SystemExit):
             CLI().main()
         assert caplog.messages[-1] == log_message
+
+    def test_publish_download_successful(  # pylint: disable=too-many-arguments
+        self,
+        mocker,
+        payload_file,
+        patched_insights_credentials,
+        caplog,
+        requests_mock,
+    ):
+        """Testing successful report id download from insights publish."""
+        caplog.set_level("INFO")
+        mocker.patch.object(
+            InsightsPublishCommand, "_make_publish_request", return_value=True
+        )
+        requests_mock.request(
+            method="GET",
+            url=REPORT_URI + "1" + INSIGHTS_PATH_SUFFIX,
+            status_code=200,
+            content=payload_file.read_bytes(),
+        )
+
+        sys.argv = [
+            "/bin/qpc",
+            "insights",
+            "publish",
+            "--report",
+            "1",
+        ]
+        CLI().main()
+        assert caplog.messages[-1] == messages.INSIGHTS_REPORT_DOWNLOAD_SUCCESSFUL
+
+    @pytest.mark.parametrize(
+        "status_code, error_message",
+        [
+            (401, (messages.SERVER_LOGIN_REQUIRED % "qpc")),
+            (404, (messages.DOWNLOAD_NO_REPORT_FOUND % "1")),
+            (500, messages.SERVER_INTERNAL_ERROR),
+        ],
+    )
+    def test_insights_publish_download_error(  # pylint: disable=too-many-arguments
+        self,
+        caplog,
+        requests_mock,
+        status_code,
+        error_message,
+    ):
+        """Testing errors in download for insights publish."""
+        caplog.set_level("ERROR")
+        requests_mock.request(
+            method="GET",
+            url=f"{REPORT_URI}1{INSIGHTS_PATH_SUFFIX}",
+            status_code=status_code,
+        )
+        sys.argv = [
+            "/bin/qpc",
+            "insights",
+            "publish",
+            "--report",
+            "1",
+        ]
+        with pytest.raises(SystemExit):
+            CLI().main()
+        assert caplog.messages[-1] == error_message
+
+    def test_if_file_is_successfully_created_and_deleted(
+        self,
+        mocker,
+        caplog,
+        patched_insights_credentials,
+        payload_file,
+    ):
+        """Testing if file created during report download is deleted after published."""
+        caplog.set_level("INFO")
+        mocker.patch.object(
+            InsightsPublishCommand,
+            "_download_insights_report",
+            return_value=str(payload_file),
+        )
+        mock_validate_report_name = mocker.patch.object(
+            InsightsPublishCommand, "_validate_insights_report_name"
+        )
+        mock_validate_report_content = mocker.patch.object(
+            InsightsPublishCommand, "_validate_insights_report_content"
+        )
+        mocker.patch.object(
+            InsightsPublishCommand, "_make_publish_request", return_value=True
+        )
+
+        sys.argv = [
+            "/bin/qpc",
+            "insights",
+            "publish",
+            "--report",
+            "1",
+        ]
+        CLI().main()
+
+        mock_validate_report_name.assert_called_with(str(payload_file))
+        mock_validate_report_content.assert_called_with(str(payload_file))
+
+        assert not payload_file.exists()

--- a/qpc/messages.py
+++ b/qpc/messages.py
@@ -374,3 +374,5 @@ INSIGHTS_REPORT_CONTENT_NOT_JSON = (
 INSIGHTS_REPORT_CONTENT_UNEXPECTED = (
     f"{_INVALID_PREFIX} Insights report tarball contains an unexpected file structure."
 )
+INSIGHTS_REPORT_DOWNLOAD_SUCCESSFUL = "The report was successfully downloaded."
+INSIGHTS_REPORT_DOWNLOAD_ERROR = "There was a problem while downloading your report."

--- a/qpc/report/deployments.py
+++ b/qpc/report/deployments.py
@@ -127,7 +127,7 @@ class ReportDeploymentsCommand(CliCommand):
             print(err_msg)
             sys.exit(1)
 
-    def _handle_response_error(self):
+    def _handle_response_error(self):  # pylint: disable=arguments-differ
         if self.args.report_id is None:
             if self.response.status_code == 428:
                 print(_(messages.REPORT_COULD_NOT_BE_MASKED_SJ) %

--- a/qpc/report/details.py
+++ b/qpc/report/details.py
@@ -126,7 +126,7 @@ class ReportDetailsCommand(CliCommand):
             print(err_msg)
             sys.exit(1)
 
-    def _handle_response_error(self):
+    def _handle_response_error(self):  # pylint: disable=arguments-differ
         if self.args.report_id is None:
             print(_(messages.REPORT_NO_DETAIL_REPORT_FOR_SJ %
                     self.args.scan_job_id))

--- a/qpc/report/download.py
+++ b/qpc/report/download.py
@@ -102,7 +102,7 @@ class ReportDownloadCommand(CliCommand):
             print(err_msg)
             sys.exit(1)
 
-    def _handle_response_error(self):
+    def _handle_response_error(self):  # pylint: disable=arguments-differ
         if self.response.status_code == 428:
             print(_(messages.DOWNLOAD_NO_MASK_REPORT) %
                   self.args.report_id)

--- a/qpc/report/insights.py
+++ b/qpc/report/insights.py
@@ -104,7 +104,7 @@ class ReportInsightsCommand(CliCommand):
             print(err_msg)
             sys.exit(1)
 
-    def _handle_response_error(self):
+    def _handle_response_error(self):  # pylint: disable=arguments-differ
         if self.args.report_id is None:
             print(_(messages.REPORT_NO_INSIGHTS_REPORT_FOR_SJ %
                     self.args.scan_job_id))

--- a/qpc/report/merge.py
+++ b/qpc/report/merge.py
@@ -190,7 +190,7 @@ class ReportMergeCommand(CliCommand):
                 PKG_NAME,
                 json_data.get('id'))))
 
-    def _handle_response_error(self):
+    def _handle_response_error(self):  # pylint: disable=arguments-differ
         json_data = self.response.json()
         reports = json_data.get('reports')
         if reports:

--- a/qpc/report/merge_status.py
+++ b/qpc/report/merge_status.py
@@ -58,6 +58,6 @@ class ReportMergeStatusCommand(CliCommand):
                                                   PKG_NAME,
                                                   json_data.get('report_id'))))
 
-    def _handle_response_error(self):
+    def _handle_response_error(self):  # pylint: disable=arguments-differ
         print(_(messages.MERGE_JOB_ID_NOT_FOUND % self.args.job_id))
         sys.exit(1)

--- a/qpc/report/upload.py
+++ b/qpc/report/upload.py
@@ -89,7 +89,7 @@ class ReportUploadCommand(CliCommand):
                 PKG_NAME,
                 json_data.get('id'))))
 
-    def _handle_response_error(self):
+    def _handle_response_error(self):  # pylint: disable=arguments-differ
         json_data = self.response.json()
         print(_(messages.REPORT_FAILED_TO_UPLOADED) % json_data.get('error'))
         sys.exit(1)

--- a/qpc/scan/show.py
+++ b/qpc/scan/show.py
@@ -70,6 +70,6 @@ class ScanShowCommand(CliCommand):
         data = pretty_print(json_data)
         print(data)
 
-    def _handle_response_error(self):
+    def _handle_response_error(self):  # pylint: disable=arguments-differ
         print(_(messages.SCAN_DOES_NOT_EXIST % self.args.name))
         sys.exit(1)

--- a/qpc/server/status.py
+++ b/qpc/server/status.py
@@ -71,6 +71,6 @@ class ServerStatusCommand(CliCommand):
         else:
             print(status)
 
-    def _handle_response_error(self):
+    def _handle_response_error(self):  # pylint: disable=arguments-differ
         print(_(messages.SERVER_STATUS_FAILURE))
         sys.exit(1)


### PR DESCRIPTION
  Add new argument --report to InsightsPublishCommand which downloads the
 insights report from qpc server and publishes it to insights.
 
Implementation of DISCOVERY-170

A few observations regarding linting:
- publish.py line 183 disable=consider-using-with(I don't think a context manager is necessary in this situation since we make sure to delete the file after it was published)
