### PR TITLE
Feature/password prompt insights add_login

### DIFF
--- a/qpc/cred/utils.py
+++ b/qpc/cred/utils.py
@@ -18,15 +18,9 @@ from logging import getLogger
 
 from qpc import messages
 from qpc.translation import _
+from qpc.utils import check_if_prompt_is_not_empty
 
 log = getLogger("qpc")
-
-
-def check_if_prompt_is_not_empty(pass_prompt):
-    """Validate user prompt."""
-    if not pass_prompt:
-        log.error(_(messages.PROMPT_INPUT))
-        raise SystemExit(2)
 
 
 def get_password(args, req_payload, add_none=True):

--- a/qpc/insights/conftest.py
+++ b/qpc/insights/conftest.py
@@ -18,3 +18,10 @@ def _setup_server_config_file(server_config):
     # We wanted the fixture to be widely available,
     # but only called when necessary as we use autouse flag
 
+
+@pytest.fixture
+def insights_login_password_input(monkeypatch):
+    """Mock insights add_login return password from prompt."""
+    yield monkeypatch.setattr(
+        "qpc.insights.utils.getpass", lambda x: "insights-test-password"
+    )

--- a/qpc/insights/conftest.py
+++ b/qpc/insights/conftest.py
@@ -1,0 +1,20 @@
+# Copyright (c) 2022 Red Hat, Inc.
+#
+# This software is licensed to you under the GNU General Public License,
+# version 3 (GPLv3). There is NO WARRANTY for this software, express or
+# implied, including the implied warranties of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv3
+# along with this software; if not, see
+# https://www.gnu.org/licenses/gpl-3.0.txt.
+#
+"""pytest configuration file."""
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def _setup_server_config_file(server_config):
+    """Disable the server_config feature in conftest's root folder."""
+    # We wanted the fixture to be widely available,
+    # but only called when necessary as we use autouse flag
+

--- a/qpc/insights/login.py
+++ b/qpc/insights/login.py
@@ -16,7 +16,10 @@ from logging import getLogger
 from qpc import insights, messages
 from qpc.clicommand import CliCommand
 from qpc.exceptions import QPCError
-from qpc.insights.utils import validate_username_and_password
+from qpc.insights.utils import (
+    build_insights_login_config_dict,
+    validate_username_and_password,
+)
 from qpc.translation import _
 from qpc.utils import write_insights_login_config
 
@@ -54,18 +57,14 @@ class InsightsAddLoginCommand(CliCommand):
         self.parser.add_argument(
             "--password",
             dest="password",
-            type=validate_username_and_password,
-            metavar="PASSWORD",
             help=_(messages.INSIGHTS_ADD_PASS_USER_HELP),
+            action="store_true",
             required=True,
         )
 
     def _do_command(self):
         """Persist insights login configuration."""
-        login_config = {
-            "username": self.args.username,
-            "password": self.args.password,
-        }
+        login_config = build_insights_login_config_dict(self.args)
         try:
             write_insights_login_config(login_config)
         except QPCError as err:

--- a/qpc/insights/tests_insights_configure.py
+++ b/qpc/insights/tests_insights_configure.py
@@ -10,7 +10,8 @@
 """Test the CLI module."""
 import os
 import sys
-import unittest
+
+import pytest
 
 from qpc import utils
 from qpc.cli import CLI
@@ -21,47 +22,35 @@ from qpc.utils import (
     DEFAULT_USE_HTTP_INSIGHTS_CONFIG,
     read_insights_config,
     write_insights_config,
-    write_server_config,
 )
 
 
-class InsightsConfigureTests(unittest.TestCase):
+class TestInsightsConfigure:
     """Class for testing insights host configuration."""
-
-    def setUp(self):
-        """Create test setup."""
-        write_server_config(
-            {
-                "host": "127.0.0.1",
-                "port": 8000,
-                "use_http": True,
-                "require_token": False,
-            }
-        )
 
     def test_insights_config_bad_port(self):
         """Testing insights configure when receiving bad port."""
         sys.argv = ["/bin/qpc", "insights", "config", "--port", "abc"]
-        with self.assertRaises(SystemExit):
+        with pytest.raises(SystemExit):
             CLI().main()
 
     def test_insights_config_empty_host(self):
-        """Testing insights configure when receiving bad host."""
+        """Testing insights configure when receiving empty host."""
         sys.argv = ["/bin/qpc", "insights", "config", "--host", ""]
-        with self.assertRaises(SystemExit):
+        with pytest.raises(SystemExit):
             CLI().main()
 
     def test_insights_config_bad_host(self):
         """Testing insights configure when receiving bad host."""
         sys.argv = ["/bin/qpc", "insights", "config", "--host", None]
-        with self.assertRaises(SystemExit):
+        with pytest.raises(SystemExit):
             CLI().main()
 
     def test_success_default_config_no_args(self):
         """Testing if method returns default config dict when no arguments."""
         config = read_insights_config()
-        self.assertDictEqual(config, DEFAULT_INSIGHTS_CONFIG)
-        self.assertFalse(os.path.exists(utils.INSIGHTS_CONFIG))
+        assert config == DEFAULT_INSIGHTS_CONFIG
+        assert not os.path.exists(utils.INSIGHTS_CONFIG)
 
     def test_success_config_insights(self):
         """Testing insights configure green path."""
@@ -77,33 +66,33 @@ class InsightsConfigureTests(unittest.TestCase):
         ]
         CLI().main()
         config = read_insights_config()
-        self.assertEqual(config["host"], "console.insights.test")
-        self.assertEqual(config["port"], 200)
-        self.assertEqual(config["use_http"], True)
+        assert config["host"] == "console.insights.test"
+        assert config["port"] == 200
+        assert config["use_http"]
 
     def test_insights_config_default_host(self):
         """Testing insights configure default host."""
         sys.argv = ["/bin/qpc", "insights", "config", "--port", "200"]
         CLI().main()
         config = read_insights_config()
-        self.assertEqual(config["host"], DEFAULT_HOST_INSIGHTS_CONFIG)
-        self.assertEqual(config["port"], 200)
-        self.assertEqual(config["use_http"], DEFAULT_USE_HTTP_INSIGHTS_CONFIG)
+        assert config["host"] == DEFAULT_HOST_INSIGHTS_CONFIG
+        assert config["port"] == 200
+        assert config["use_http"] == DEFAULT_USE_HTTP_INSIGHTS_CONFIG
 
     def test_insights_config_default_port(self):
         """Testing insights configure default port."""
         sys.argv = ["/bin/qpc", "insights", "config", "--host", "console.insights.test"]
         CLI().main()
         config = read_insights_config()
-        self.assertEqual(config["host"], "console.insights.test")
-        self.assertEqual(config["port"], DEFAULT_PORT_INSIGHTS_CONFIG)
-        self.assertEqual(config["use_http"], DEFAULT_USE_HTTP_INSIGHTS_CONFIG)
+        assert config["host"] == "console.insights.test"
+        assert config["port"] == DEFAULT_PORT_INSIGHTS_CONFIG
+        assert config["use_http"] == DEFAULT_USE_HTTP_INSIGHTS_CONFIG
 
     def test_invalid_configuration(self):
         """Test reading bad JSON on cli start."""
         write_insights_config({})
 
         config = read_insights_config()
-        self.assertEqual(config["host"], DEFAULT_HOST_INSIGHTS_CONFIG)
-        self.assertEqual(config["port"], DEFAULT_PORT_INSIGHTS_CONFIG)
-        self.assertEqual(config["use_http"], DEFAULT_USE_HTTP_INSIGHTS_CONFIG)
+        assert config["host"] == DEFAULT_HOST_INSIGHTS_CONFIG
+        assert config["port"] == DEFAULT_PORT_INSIGHTS_CONFIG
+        assert config["use_http"] == DEFAULT_USE_HTTP_INSIGHTS_CONFIG

--- a/qpc/insights/tests_insights_login.py
+++ b/qpc/insights/tests_insights_login.py
@@ -13,6 +13,7 @@ import sys
 
 import pytest
 
+from qpc import messages
 from qpc.cli import CLI
 from qpc.utils import read_insights_login_config
 
@@ -84,8 +85,11 @@ class TestInsightsAddLogin:
         assert out == ""
         assert expected_error in err
 
-    def test_success_add_insights_login_config(self):
+    def test_success_add_insights_login_config(
+        self, insights_login_password_input, caplog
+    ):
         """Testing insights login config green path."""
+        caplog.set_level("INFO")
         sys.argv = [
             "/bin/qpc",
             "insights",
@@ -93,9 +97,9 @@ class TestInsightsAddLogin:
             "--username",
             "insights-test-user",
             "--password",
-            "insights-test-password",
         ]
         CLI().main()
+        assert caplog.messages[-1] == messages.INSIGHTS_LOGIN_CONFIG_SUCCESS
         config = read_insights_login_config()
         assert config["username"] == "insights-test-user"
         assert config["password"] == "insights-test-password"

--- a/qpc/insights/tests_insights_login.py
+++ b/qpc/insights/tests_insights_login.py
@@ -10,57 +10,79 @@
 """Test the CLI module."""
 
 import sys
-import unittest
+
+import pytest
 
 from qpc.cli import CLI
-from qpc.utils import read_insights_login_config, write_server_config
+from qpc.utils import read_insights_login_config
 
 
-class InsightsAddLoginTests(unittest.TestCase):
+class TestInsightsAddLogin:
     """Class for testing insights add login command."""
 
-    def setUp(self):
-        """Create test setup."""
-        # All cli commands require qpc config and qpc login to be executed,
-        # require_token must be False, so we don't have to pass login info
-        write_server_config(
-            {
-                "host": "127.0.0.1",
-                "port": 8000,
-                "use_http": True,
-                "require_token": False,
-            }
-        )
-
-    def test_insight_login_req_args_err(self):
+    def test_insight_login_req_args_err(self, capsys):
         """Testing if insights add-login command requires args."""
         sys.argv = ["/bin/qpc", "insights", "add_login"]
-        with self.assertRaises(SystemExit):
+        with pytest.raises(SystemExit):
             CLI().main()
+        out, err = capsys.readouterr()
+        expected_error = (
+            "error: the following arguments are required: --username, --password"
+        )
+        assert out == ""
+        assert expected_error in err
 
-    def test_insights_config_bad_username(self):
+    def test_insights_config_bad_username(self, capsys):
         """Testing insights configure when receiving bad username."""
-        sys.argv = ["/bin/qpc", "insights", "add-login", "--username", None]
-        with self.assertRaises(SystemExit):
+        sys.argv = ["/bin/qpc", "insights", "add_login", "--username", None]
+        with pytest.raises(SystemExit):
             CLI().main()
+        out, err = capsys.readouterr()
+        expected_error = "invalid validate_username_and_password value: None"
+        assert out == ""
+        assert expected_error in err
 
-    def test_insights_config_empty_username(self):
-        """Testing insights configure when receiving bad username."""
-        sys.argv = ["/bin/qpc", "insights", "add-login", "--username", ""]
-        with self.assertRaises(SystemExit):
+    def test_insights_config_empty_username(self, capsys):
+        """Testing insights configure when receiving empty username."""
+        sys.argv = ["/bin/qpc", "insights", "add_login", "--username", ""]
+        with pytest.raises(SystemExit):
             CLI().main()
+        out, err = capsys.readouterr()
+        expected_error = "error: argument --username: The argument value is invalid."
+        assert out == ""
+        assert expected_error in err
 
     def test_insights_config_bad_password(self):
-        """Testing insights configure when receiving bad username."""
-        sys.argv = ["/bin/qpc", "insights", "add-login", "--password", None]
-        with self.assertRaises(SystemExit):
+        """Testing insights configure when receiving bad password."""
+        sys.argv = [
+            "/bin/qpc",
+            "insights",
+            "add_login",
+            "--username",
+            "test_username",
+            "--password",
+            None,
+        ]
+        with pytest.raises(TypeError):
             CLI().main()
 
-    def test_insights_config_empty_password(self):
-        """Testing insights configure when receiving bad username."""
-        sys.argv = ["/bin/qpc", "insights", "add-login", "--password", ""]
-        with self.assertRaises(SystemExit):
+    def test_insights_config_empty_password(self, capsys):
+        """Testing insights configure when receiving empty password."""
+        sys.argv = [
+            "/bin/qpc",
+            "insights",
+            "add_login",
+            "--username",
+            "test-username",
+            "--password",
+            "",
+        ]
+        with pytest.raises(SystemExit):
             CLI().main()
+        out, err = capsys.readouterr()
+        expected_error = "qpc: error: unrecognized arguments: "
+        assert out == ""
+        assert expected_error in err
 
     def test_success_add_insights_login_config(self):
         """Testing insights login config green path."""
@@ -75,11 +97,11 @@ class InsightsAddLoginTests(unittest.TestCase):
         ]
         CLI().main()
         config = read_insights_login_config()
-        self.assertEqual(config["username"], "insights-test-user")
-        self.assertEqual(config["password"], "insights-test-password")
+        assert config["username"] == "insights-test-user"
+        assert config["password"] == "insights-test-password"
 
     def test_run_command_no_config(self):
         """Test running command without config."""
         sys.argv = ["/bin/qpc", "insights", "add_login"]
-        with self.assertRaises(SystemExit):
+        with pytest.raises(SystemExit):
             CLI().main()

--- a/qpc/insights/tests_insights_publish.py
+++ b/qpc/insights/tests_insights_publish.py
@@ -20,25 +20,6 @@ from qpc import messages
 from qpc.cli import CLI
 from qpc.insights import INGRESS_REPORT_URI, INSIGHTS_PATH_SUFFIX, REPORT_URI
 from qpc.insights.publish import InsightsPublishCommand
-from qpc.utils import write_server_config
-
-
-@pytest.fixture(autouse=True)
-def _setup_server_config_file():
-    """
-    Create server config with require_token set to False.
-
-    Since all cli commands require qpc config and qpc login to be executed,
-    require_token must be False, to avoid passing login info
-    """
-    return write_server_config(
-        {
-            "host": "127.0.0.1",
-            "port": 8000,
-            "use_http": True,
-            "require_token": False,
-        }
-    )
 
 
 @pytest.fixture

--- a/qpc/insights/utils.py
+++ b/qpc/insights/utils.py
@@ -15,12 +15,13 @@ from __future__ import print_function
 
 import re
 from argparse import ArgumentTypeError
-
 # pylint: disable=no-name-in-module,import-error
 from distutils.version import LooseVersion
+from getpass import getpass
 
 from qpc import messages
 from qpc.translation import _
+from qpc.utils import check_if_prompt_is_not_empty
 
 
 class InsightsCommands():
@@ -158,3 +159,19 @@ def validate_username_and_password(arg):
     if argument_re.search(arg) is None:
         raise ArgumentTypeError("The argument value is invalid.")
     return arg
+
+
+def build_insights_login_config_dict(args):
+    """Construct login config dict from command line arguments.
+
+    :param args: the command line arguments
+    :returns: insights login config dict
+    """
+    config_dict = {}
+    config_dict["username"] = args.username
+    if getattr(args, "password", None):
+        password_prompt = getpass(messages.INSIGHTS_LOGIN_PASSWORD)
+        check_if_prompt_is_not_empty(password_prompt)
+        validate_username_and_password(password_prompt)
+        config_dict["password"] = password_prompt
+    return config_dict

--- a/qpc/insights/utils.py
+++ b/qpc/insights/utils.py
@@ -15,8 +15,9 @@ from __future__ import print_function
 
 import re
 from argparse import ArgumentTypeError
+
 # pylint: disable=no-name-in-module,import-error
-from distutils.version import LooseVersion
+from distutils.version import LooseVersion  # noqa:I202
 from getpass import getpass
 
 from qpc import messages

--- a/qpc/messages.py
+++ b/qpc/messages.py
@@ -341,6 +341,7 @@ SERVER_TOO_OLD_FOR_CLI = 'The CLI requires a minimum server version of %s.  '\
 OUTPUT_FILE_TYPE = "The output file's extension is required to be %s."
 INSIGHTS_ADD_USERNAME_USER_HELP = "The username used to log in to insights."
 INSIGHTS_ADD_PASS_USER_HELP = "The password used to log in to insights."
+INSIGHTS_LOGIN_PASSWORD = "Provide a password for insights authentication: "
 INSIGHTS_LOGIN_CONFIG_SUCCESS = (
     "Insights username and password were successfully saved."
 )

--- a/qpc/test_utils.py
+++ b/qpc/test_utils.py
@@ -10,8 +10,8 @@
 """Test qpc cred utils."""
 import pytest
 
-from qpc.cred.utils import check_if_prompt_is_not_empty
 from qpc.messages import PROMPT_INPUT
+from qpc.utils import check_if_prompt_is_not_empty
 
 
 @pytest.mark.parametrize("pass_prompt", ["", None])

--- a/qpc/utils.py
+++ b/qpc/utils.py
@@ -585,3 +585,10 @@ def decrypt_password(password):
             "There was a problem while decrypting your password."
         ) from exc
     return decrypted_password.decode()
+
+
+def check_if_prompt_is_not_empty(pass_prompt):
+    """Validate user prompt."""
+    if not pass_prompt:
+        log.error(t(messages.PROMPT_INPUT))
+        raise SystemExit(2)


### PR DESCRIPTION
- Test improvements on qpc insights test modules
- The user will be prompted for his password instead of pasting it directly in terminal.

This implements [DISCOVERY-200]