### PR TITLE
Correct message for ocp cred token prompt

### DIFF
--- a/qpc/cred/conftest.py
+++ b/qpc/cred/conftest.py
@@ -21,4 +21,6 @@ def _setup_server_config_file(server_config):
 @pytest.fixture
 def openshift_token_input(monkeypatch):
     """Mock Openshift token return from prompt."""
-    yield monkeypatch.setattr("qpc.cred.utils.getpass", lambda: "mocked_input_password")
+    yield monkeypatch.setattr(
+        "qpc.cred.utils.getpass", lambda x: "mocked_input_password"
+    )

--- a/qpc/cred/test_openshift_cred_add.py
+++ b/qpc/cred/test_openshift_cred_add.py
@@ -52,7 +52,7 @@ class TestOpenShiftAddCredential:
         with pytest.raises(SystemExit):
             CLI().main()
         out, err = capsys.readouterr()
-        assert out == messages.OPENSHIFT_TOKEN + "\n"
+        assert out == ""
         assert err_log_message in err
 
     def test_add_no_type(
@@ -140,10 +140,5 @@ class TestOpenShiftAddCredential:
         ]
         CLI().main()
         out, err = capsys.readouterr()
-        assert out == (
-            messages.OPENSHIFT_TOKEN
-            + "\n"
-            + messages.CRED_ADDED % "openshift_credential"
-            + "\n"
-        )
+        assert out == (messages.CRED_ADDED % "openshift_credential" + "\n")
         assert err == ""

--- a/qpc/cred/test_openshift_cred_edit.py
+++ b/qpc/cred/test_openshift_cred_edit.py
@@ -51,12 +51,7 @@ class TestOpenShiftEditCredential:
         ]
         CLI().main()
         out, err = capsys.readouterr()
-        assert out == (
-            messages.OPENSHIFT_TOKEN
-            + "\n"
-            + messages.CRED_UPDATED % "openshift_cred"
-            + "\n"
-        )
+        assert out == (messages.CRED_UPDATED % "openshift_cred" + "\n")
         assert err == ""
 
     def test_edit_green_path(
@@ -89,12 +84,7 @@ class TestOpenShiftEditCredential:
         ]
         CLI().main()
         out, err = capsys.readouterr()
-        assert out == (
-            messages.OPENSHIFT_TOKEN
-            + "\n"
-            + messages.CRED_UPDATED % "openshift_cred_2"
-            + "\n"
-        )
+        assert out == (messages.CRED_UPDATED % "openshift_cred_2" + "\n")
         assert err == ""
 
     @pytest.mark.parametrize(

--- a/qpc/cred/utils.py
+++ b/qpc/cred/utils.py
@@ -59,8 +59,7 @@ def get_password(args, req_payload, add_none=True):
     elif add_none:
         req_payload['become_password'] = None
     if getattr(args, "token", None):
-        print(_(messages.OPENSHIFT_TOKEN))
-        token_prompt = getpass()
+        token_prompt = getpass(messages.OPENSHIFT_TOKEN)
         check_if_prompt_is_not_empty(token_prompt)
         req_payload["auth_token"] = token_prompt
     elif add_none:

--- a/qpc/messages.py
+++ b/qpc/messages.py
@@ -254,7 +254,7 @@ SUDO_PASSWORD = 'Provide a password for sudo.'
 SSH_PASSPHRASE = 'Provide a passphrase for the SSH keyfile.'
 BECOME_PASSWORD = 'Provide a privilege escalation password to be used when '\
     'running a network scan.'
-OPENSHIFT_TOKEN = "Provide a token for OpenShift authentication."
+OPENSHIFT_TOKEN = "Provide a token for OpenShift authentication.\nToken: "
 
 MERGE_JOB_ID_NOT_FOUND = 'Report merge job %s not found.'
 MERGE_JOB_ID_STATUS = 'Report merge job %s is %s.'


### PR DESCRIPTION
Incorrect message requests the user to insert a password instead of a token.

This fix refers to [DISCOVERY-185]