### PR TITLE
Add token to mutually exclusive group

### DIFF
--- a/qpc/cred/edit.py
+++ b/qpc/cred/edit.py
@@ -57,6 +57,12 @@ class CredEditCommand(CliCommand):
             help=_(messages.CRED_PWD_HELP),
         )
         group.add_argument(
+            "--token",
+            dest="token",
+            action="store_true",
+            help=_(messages.CRED_TOKEN_HELP),
+        )
+        group.add_argument(
             "--sshkeyfile",
             dest="filename",
             metavar="FILENAME",
@@ -86,12 +92,6 @@ class CredEditCommand(CliCommand):
             dest="become_password",
             action="store_true",
             help=_(messages.CRED_BECOME_PASSWORD_HELP),
-        )
-        self.parser.add_argument(
-            "--token",
-            dest="token",
-            action="store_true",
-            help=_(messages.CRED_TOKEN_HELP),
         )
         self.cred_type = None
 

--- a/qpc/cred/test_openshift_cred_edit.py
+++ b/qpc/cred/test_openshift_cred_edit.py
@@ -184,3 +184,44 @@ class TestOpenShiftEditCredential:
         out, err = capsys.readouterr()
         assert out == ""
         assert "error: unrecognized arguments: --type satellite" in err
+
+    def test_edit_with_token_and_password_as_args(
+        self,
+        capsys,
+    ):
+        """Test openshift cred edit with password and token args."""
+        sys.argv = [
+            "/bin/qpc",
+            "cred",
+            "edit",
+            "--name",
+            "openshift_cred",
+            "--password",
+            "--token",
+        ]
+        with pytest.raises(SystemExit):
+            CLI().main()
+        out, err = capsys.readouterr()
+        assert out == ""
+        assert "argument --token: not allowed with argument --password" in err
+
+    def test_edit_with_token_and_sshkeyfile_as_args(
+        self,
+        capsys,
+    ):
+        """Test openshift cred edit with token and sshkeyfile args."""
+        sys.argv = [
+            "/bin/qpc",
+            "cred",
+            "edit",
+            "--name",
+            "openshift_cred",
+            "--sshkeyfile",
+            "mock_path/test.pem",
+            "--token",
+        ]
+        with pytest.raises(SystemExit):
+            CLI().main()
+        out, err = capsys.readouterr()
+        assert out == ""
+        assert "argument --token: not allowed with argument --sshkeyfile" in err


### PR DESCRIPTION
Token, password and sshkey are mutually exclusive arguments and cli shouldn't allow user to select more than one of them simultaneously.