### PR TITLE
fix(insights): return error if report doesnt exist

### DIFF
--- a/qpc/insights/publish.py
+++ b/qpc/insights/publish.py
@@ -65,10 +65,10 @@ class InsightsPublishCommand(CliCommand):
     def _validate_insights_report_name(self, input_file):
         """Validate if report file exists and its file extension (tar.gz)."""
         if not os.path.isfile(input_file):
-            log.info(_(messages.INSIGHTS_LOCAL_REPORT_NOT), input_file)
+            log.error(_(messages.INSIGHTS_LOCAL_REPORT_NOT), input_file)
             sys.exit(1)
         if "tar.gz" not in input_file:
-            log.info(_(messages.INSIGHTS_LOCAL_REPORT_NOT_TAR_GZ), input_file)
+            log.error(_(messages.INSIGHTS_LOCAL_REPORT_NOT_TAR_GZ), input_file)
             sys.exit(1)
 
     def _validate_insights_report_content(self, input_file):

--- a/qpc/insights/tests_insights_publish.py
+++ b/qpc/insights/tests_insights_publish.py
@@ -152,7 +152,7 @@ class TestInsightsPublishCommand:
         caplog,
     ):
         """Testing if--input-file will accept files with inappropriate extensions."""
-        caplog.set_level("INFO")
+        caplog.set_level("ERROR")
         sys.argv = [
             "/bin/qpc",
             "insights",
@@ -170,7 +170,7 @@ class TestInsightsPublishCommand:
 
     def test_validate_report_name_if_not_file(self, tmp_path, caplog):
         """Testing if insights publish --input-file will accept dir as file."""
-        caplog.set_level("INFO")
+        caplog.set_level("ERROR")
         sys.argv = [
             "/bin/qpc",
             "insights",


### PR DESCRIPTION
Return error message to user if report doesnt exist or if report is not in expected format.
This PR implements[ [DISCOVERY-213]](https://issues.redhat.com/browse/DISCOVERY-213)
![qpc](https://user-images.githubusercontent.com/63803651/215481724-16b42c46-43f2-48c5-b4a0-c4231718690c.jpg)
