### PR TITLE
CLI shouldn't force output file for json reports 

### DIFF
--- a/qpc/report/conftest.py
+++ b/qpc/report/conftest.py
@@ -1,0 +1,10 @@
+"""pytest configuration file."""
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def _setup_server_config_file(server_config):
+    """Disable the server_config feature in conftest's root folder."""
+    # We wanted the fixture to be widely available,
+    # but only called when necessary as we use autouse flag

--- a/qpc/report/deployments.py
+++ b/qpc/report/deployments.py
@@ -14,6 +14,7 @@
 from __future__ import print_function
 
 import sys
+from logging import getLogger
 
 from requests import codes
 
@@ -27,6 +28,8 @@ from qpc.utils import (
     validate_write_file,
     write_file,
 )
+
+log = getLogger("qpc")
 
 
 # pylint: disable=too-few-public-methods
@@ -159,10 +162,10 @@ class ReportDeploymentsCommand(CliCommand):
 
         try:
             write_file(self.args.path, file_content)
-            print(_(messages.REPORT_SUCCESSFULLY_WRITTEN))
+            log.info(_(messages.REPORT_SUCCESSFULLY_WRITTEN))
         except EnvironmentError as err:
             err_msg = _(messages.WRITE_FILE_ERROR % (self.args.path, err))
-            print(err_msg)
+            log.error(err_msg)
             sys.exit(1)
 
     def _handle_response_error(self):  # pylint: disable=arguments-differ

--- a/qpc/report/deployments.py
+++ b/qpc/report/deployments.py
@@ -87,7 +87,6 @@ class ReportDeploymentsCommand(CliCommand):
             dest="path",
             metavar="PATH",
             help=_(messages.REPORT_PATH_HELP),
-            required=True,
         )
         self.parser.add_argument(
             "--mask",
@@ -114,7 +113,8 @@ class ReportDeploymentsCommand(CliCommand):
             check_extension(extension, self.args.path)
 
         try:
-            validate_write_file(self.args.path, "output-file")
+            if self.args.path is not None:
+                validate_write_file(self.args.path, "output-file")
         except ValueError as error:
             print(error)
             sys.exit(1)

--- a/qpc/report/details.py
+++ b/qpc/report/details.py
@@ -87,7 +87,6 @@ class ReportDetailsCommand(CliCommand):
             dest="path",
             metavar="PATH",
             help=_(messages.REPORT_PATH_HELP),
-            required=True,
         )
         self.parser.add_argument(
             "--mask",
@@ -113,7 +112,8 @@ class ReportDetailsCommand(CliCommand):
         if extension:
             check_extension(extension, self.args.path)
         try:
-            validate_write_file(self.args.path, "output-file")
+            if self.args.path:
+                validate_write_file(self.args.path, "output-file")
         except ValueError as error:
             print(error)
             sys.exit(1)

--- a/qpc/report/details.py
+++ b/qpc/report/details.py
@@ -14,6 +14,7 @@
 from __future__ import print_function
 
 import sys
+from logging import getLogger
 
 from requests import codes
 
@@ -27,6 +28,8 @@ from qpc.utils import (
     validate_write_file,
     write_file,
 )
+
+log = getLogger("qpc")
 
 
 # pylint: disable=too-few-public-methods
@@ -156,10 +159,10 @@ class ReportDetailsCommand(CliCommand):
 
         try:
             write_file(self.args.path, file_content)
-            print(_(messages.REPORT_SUCCESSFULLY_WRITTEN))
+            log.info(_(messages.REPORT_SUCCESSFULLY_WRITTEN))
         except EnvironmentError as err:
             err_msg = _(messages.WRITE_FILE_ERROR % (self.args.path, err))
-            print(err_msg)
+            log.error(err_msg)
             sys.exit(1)
 
     def _handle_response_error(self):  # pylint: disable=arguments-differ

--- a/qpc/report/insights.py
+++ b/qpc/report/insights.py
@@ -14,6 +14,7 @@
 from __future__ import print_function
 
 import sys
+from logging import getLogger
 
 from requests import codes
 
@@ -22,6 +23,8 @@ from qpc.clicommand import CliCommand
 from qpc.request import GET, request
 from qpc.translation import _
 from qpc.utils import check_extension, validate_write_file, write_file
+
+log = getLogger("qpc")
 
 
 # pylint: disable=too-few-public-methods

--- a/qpc/report/tests_report_deployments.py
+++ b/qpc/report/tests_report_deployments.py
@@ -62,9 +62,7 @@ class ReportDeploymentsTests(unittest.TestCase):
             pass
 
     def test_deployments_report_as_json(self):
-        """Testing retreiving deployments report as json."""
-        report_out = StringIO()
-
+        """Testing retrieving deployments report as json."""
         get_scanjob_url = get_server_location() + SCAN_JOB_URI + "1"
         get_scanjob_json_data = {"id": 1, "report_id": 1}
         get_report_url = get_server_location() + REPORT_URI + "1/deployments/"
@@ -88,20 +86,16 @@ class ReportDeploymentsTests(unittest.TestCase):
                 path=self.test_json_filename,
                 mask=False,
             )
-            with redirect_stdout(report_out):
+            with self.assertLogs(level="INFO") as log:
                 nac.main(args)
-                self.assertEqual(
-                    report_out.getvalue().strip(), messages.REPORT_SUCCESSFULLY_WRITTEN
-                )
+                self.assertIn(messages.REPORT_SUCCESSFULLY_WRITTEN, log.output[-1])
                 with open(self.test_json_filename, "r", encoding="utf-8") as json_file:
                     data = json_file.read()
                     file_content_dict = json.loads(data)
                 self.assertDictEqual(get_report_json_data, file_content_dict)
 
     def test_deployments_report_as_json_report_id(self):
-        """Testing retreiving deployments report as json with report id."""
-        report_out = StringIO()
-
+        """Testing retrieving deployments report as json with report id."""
         get_report_url = get_server_location() + REPORT_URI + "1/deployments/"
         get_report_json_data = {"id": 1, "report": [{"key": "value"}]}
         test_dict = {self.test_json_filename: get_report_json_data}
@@ -122,11 +116,9 @@ class ReportDeploymentsTests(unittest.TestCase):
                 path=self.test_json_filename,
                 mask=False,
             )
-            with redirect_stdout(report_out):
+            with self.assertLogs(level="INFO") as log:
                 nac.main(args)
-                self.assertEqual(
-                    report_out.getvalue().strip(), messages.REPORT_SUCCESSFULLY_WRITTEN
-                )
+                self.assertIn(messages.REPORT_SUCCESSFULLY_WRITTEN, log.output[-1])
                 with open(self.test_json_filename, "r", encoding="utf-8") as json_file:
                     data = json_file.read()
                     file_content_dict = json.loads(data)
@@ -134,7 +126,6 @@ class ReportDeploymentsTests(unittest.TestCase):
 
     def test_deployments_report_as_csv(self):
         """Testing retreiving deployments report as csv."""
-        report_out = StringIO()
         get_scanjob_url = get_server_location() + SCAN_JOB_URI + "1"
         get_scanjob_json_data = {"id": 1, "report_id": 1}
         get_report_url = get_server_location() + REPORT_URI + "1/deployments/"
@@ -161,11 +152,9 @@ class ReportDeploymentsTests(unittest.TestCase):
                 path=self.test_csv_filename,
                 mask=False,
             )
-            with redirect_stdout(report_out):
+            with self.assertLogs(level="INFO") as log:
                 nac.main(args)
-                self.assertEqual(
-                    report_out.getvalue().strip(), messages.REPORT_SUCCESSFULLY_WRITTEN
-                )
+                self.assertIn(messages.REPORT_SUCCESSFULLY_WRITTEN, log.output[-1])
                 with open(self.test_csv_filename, "r", encoding="utf-8") as json_file:
                     data = json_file.read()
                     file_content_dict = json.loads(data)
@@ -264,7 +253,6 @@ class ReportDeploymentsTests(unittest.TestCase):
     def test_deployments_file_fails_to_write(self, file):
         """Testing deployments failure while writing to file."""
         file.side_effect = EnvironmentError()
-        report_out = StringIO()
         get_report_url = get_server_location() + REPORT_URI + "1/deployments/"
         get_report_json_data = {"id": 1, "report": [{"key": "value"}]}
         test_dict = {self.test_json_filename: get_report_json_data}
@@ -285,11 +273,11 @@ class ReportDeploymentsTests(unittest.TestCase):
                 path=self.test_json_filename,
                 mask=False,
             )
-            with redirect_stdout(report_out):
+            with self.assertLogs(level="ERROR") as log:
                 with self.assertRaises(SystemExit):
                     nac.main(args)
                 err_msg = messages.WRITE_FILE_ERROR % (self.test_json_filename, "")
-                self.assertEqual(report_out.getvalue().strip(), err_msg)
+                self.assertIn(err_msg, log.output[0])
 
     def test_deployments_nonexistent_directory(self):
         """Testing error for nonexistent directory in output."""
@@ -439,8 +427,6 @@ class ReportDeploymentsTests(unittest.TestCase):
 
     def test_deployments_report_mask(self):
         """Testing retreiving json deployments report with masked values."""
-        report_out = StringIO()
-
         get_report_url = (
             get_server_location() + REPORT_URI + "1/deployments/" + "?mask=True"
         )
@@ -463,11 +449,9 @@ class ReportDeploymentsTests(unittest.TestCase):
                 path=self.test_json_filename,
                 mask=True,
             )
-            with redirect_stdout(report_out):
+            with self.assertLogs(level="INFO") as log:
                 nac.main(args)
-                self.assertEqual(
-                    report_out.getvalue().strip(), messages.REPORT_SUCCESSFULLY_WRITTEN
-                )
+                self.assertIn(messages.REPORT_SUCCESSFULLY_WRITTEN, log.output[-1])
                 with open(self.test_json_filename, "r", encoding="utf-8") as json_file:
                     data = json_file.read()
                     file_content_dict = json.loads(data)

--- a/qpc/report/tests_report_deployments.py
+++ b/qpc/report/tests_report_deployments.py
@@ -551,3 +551,31 @@ class ReportDeploymentsTests(unittest.TestCase):
                     report_out.getvalue().strip(),
                     messages.SERVER_TOO_OLD_FOR_CLI % ("0.9.2", "0.9.2", "0.0.45"),
                 )
+
+
+def test_deployments_report_as_json_no_output_file(caplog, capsys, requests_mock):
+    """Testing retrieving deployments report as json without output file."""
+    caplog.set_level("INFO")
+    report_url = get_server_location() + REPORT_URI + "1/deployments/"
+    report_json_data = {"id": 1, "report": [{"key": "value"}]}
+    json_filename = f"test_{time.time():.0f}.json"
+    buffer_content = create_tar_buffer({json_filename: report_json_data})
+
+    requests_mock.get(
+        report_url,
+        status_code=200,
+        content=buffer_content,
+        headers={"X-Server-Version": VERSION},
+    )
+    sys.argv = [
+        "/bin/qpc",
+        "report",
+        "deployments",
+        "--json",
+        "--report",
+        "1",
+    ]
+    CLI().main()
+    assert caplog.messages[-1] == messages.REPORT_SUCCESSFULLY_WRITTEN
+    captured = capsys.readouterr()
+    assert json.loads(captured.out)

--- a/qpc/report/tests_report_details.py
+++ b/qpc/report/tests_report_details.py
@@ -62,9 +62,7 @@ class ReportDetailsTests(unittest.TestCase):
             pass
 
     def test_detail_report_as_json(self):
-        """Testing retreiving detail report as json."""
-        report_out = StringIO()
-
+        """Testing retrieving detail report as json."""
         get_scanjob_url = get_server_location() + SCAN_JOB_URI + "1"
         get_scanjob_json_data = {"id": 1, "report_id": 1}
         get_report_url = get_server_location() + REPORT_URI + "1/details/"
@@ -88,20 +86,16 @@ class ReportDetailsTests(unittest.TestCase):
                 path=self.test_json_filename,
                 mask=False,
             )
-            with redirect_stdout(report_out):
+            with self.assertLogs(level="INFO") as log:
                 nac.main(args)
-                self.assertEqual(
-                    report_out.getvalue().strip(), messages.REPORT_SUCCESSFULLY_WRITTEN
-                )
+                self.assertIn(messages.REPORT_SUCCESSFULLY_WRITTEN, log.output[-1])
                 with open(self.test_json_filename, "r", encoding="utf-8") as json_file:
                     data = json_file.read()
                     file_content_dict = json.loads(data)
                 self.assertDictEqual(get_report_json_data, file_content_dict)
 
     def test_detail_report_as_json_report_id(self):
-        """Testing retreiving detail report as json with report id."""
-        report_out = StringIO()
-
+        """Testing retrieving detail report as json with report id."""
         get_report_url = get_server_location() + REPORT_URI + "1/details/"
         get_report_json_data = {"id": 1, "report": [{"key": "value"}]}
         test_dict = {self.test_json_filename: get_report_json_data}
@@ -122,19 +116,16 @@ class ReportDetailsTests(unittest.TestCase):
                 path=self.test_json_filename,
                 mask=False,
             )
-            with redirect_stdout(report_out):
+            with self.assertLogs(level="INFO") as log:
                 nac.main(args)
-                self.assertEqual(
-                    report_out.getvalue().strip(), messages.REPORT_SUCCESSFULLY_WRITTEN
-                )
+                self.assertIn(messages.REPORT_SUCCESSFULLY_WRITTEN, log.output[-1])
                 with open(self.test_json_filename, "r", encoding="utf-8") as json_file:
                     data = json_file.read()
                     file_content_dict = json.loads(data)
                 self.assertDictEqual(get_report_json_data, file_content_dict)
 
     def test_detail_report_as_csv(self):
-        """Testing retreiving detail report as csv."""
-        report_out = StringIO()
+        """Testing retrieving detail report as csv."""
         get_scanjob_url = get_server_location() + SCAN_JOB_URI + "1"
         get_scanjob_json_data = {"id": 1, "report_id": 1}
         get_report_url = get_server_location() + REPORT_URI + "1/details/"
@@ -161,11 +152,9 @@ class ReportDetailsTests(unittest.TestCase):
                 path=self.test_csv_filename,
                 mask=False,
             )
-            with redirect_stdout(report_out):
+            with self.assertLogs(level="INFO") as log:
                 nac.main(args)
-                self.assertEqual(
-                    report_out.getvalue().strip(), messages.REPORT_SUCCESSFULLY_WRITTEN
-                )
+                self.assertIn(messages.REPORT_SUCCESSFULLY_WRITTEN, log.output[-1])
                 with open(self.test_csv_filename, "r", encoding="utf-8") as json_file:
                     data = json_file.read()
                     file_content_dict = json.loads(data)
@@ -250,7 +239,6 @@ class ReportDetailsTests(unittest.TestCase):
     def test_details_file_fails_to_write(self, file):
         """Testing details failure while writing to file."""
         file.side_effect = EnvironmentError()
-        report_out = StringIO()
         get_report_url = get_server_location() + REPORT_URI + "1/details/"
         get_report_json_data = {"id": 1, "report": [{"key": "value"}]}
         test_dict = {self.test_json_filename: get_report_json_data}
@@ -271,11 +259,11 @@ class ReportDetailsTests(unittest.TestCase):
                 path=self.test_json_filename,
                 mask=False,
             )
-            with redirect_stdout(report_out):
+            with self.assertLogs(level="ERROR") as log:
                 with self.assertRaises(SystemExit):
                     nac.main(args)
                 err_msg = messages.WRITE_FILE_ERROR % (self.test_json_filename, "")
-                self.assertEqual(report_out.getvalue().strip(), err_msg)
+                self.assertIn(err_msg, log.output[0])
 
     def test_details_nonexistent_directory(self):
         """Testing error for nonexistent directory in output."""
@@ -424,8 +412,7 @@ class ReportDetailsTests(unittest.TestCase):
                 )
 
     def test_detail_report_as_csv_masked(self):
-        """Testing retreiving csv details report with masked query param."""
-        report_out = StringIO()
+        """Testing retrieving csv details report with masked query param."""
         get_scanjob_url = get_server_location() + SCAN_JOB_URI + "1"
         get_scanjob_json_data = {"id": 1, "report_id": 1}
         get_report_url = (
@@ -454,11 +441,9 @@ class ReportDetailsTests(unittest.TestCase):
                 path=self.test_csv_filename,
                 mask=True,
             )
-            with redirect_stdout(report_out):
+            with self.assertLogs(level="INFO") as log:
                 nac.main(args)
-                self.assertEqual(
-                    report_out.getvalue().strip(), messages.REPORT_SUCCESSFULLY_WRITTEN
-                )
+                self.assertIn(messages.REPORT_SUCCESSFULLY_WRITTEN, log.output[-1])
                 with open(self.test_csv_filename, "r", encoding="utf-8") as json_file:
                     data = json_file.read()
                     file_content_dict = json.loads(data)

--- a/qpc/report/tests_report_insights.py
+++ b/qpc/report/tests_report_insights.py
@@ -57,8 +57,6 @@ class ReportInsightsTests(unittest.TestCase):
 
     def test_insights_report_as_json(self):
         """Testing retrieving insights report as json."""
-        report_out = StringIO()
-
         get_scanjob_url = get_server_location() + SCAN_JOB_URI + "1"
         get_scanjob_json_data = {"id": 1, "report_id": 1}
         get_report_url = get_server_location() + REPORT_URI + "1/insights/"
@@ -81,16 +79,12 @@ class ReportInsightsTests(unittest.TestCase):
             args = Namespace(
                 scan_job_id="1", report_id=None, path=self.test_tar_gz_filename
             )
-            with redirect_stdout(report_out):
+            with self.assertLogs(level="INFO") as log:
                 nac.main(args)
-                self.assertEqual(
-                    report_out.getvalue().strip(), messages.REPORT_SUCCESSFULLY_WRITTEN
-                )
+                self.assertIn(messages.REPORT_SUCCESSFULLY_WRITTEN, log.output[-1])
 
     def test_insights_report_as_json_report_id(self):
         """Testing retreiving insights report as json with report id."""
-        report_out = StringIO()
-
         get_report_url = get_server_location() + REPORT_URI + "1/insights/"
         get_report_json_data = {
             "id": 1,
@@ -110,11 +104,9 @@ class ReportInsightsTests(unittest.TestCase):
             args = Namespace(
                 scan_job_id=None, report_id="1", path=self.test_tar_gz_filename
             )
-            with redirect_stdout(report_out):
+            with self.assertLogs(level="INFO") as log:
                 nac.main(args)
-                self.assertEqual(
-                    report_out.getvalue().strip(), messages.REPORT_SUCCESSFULLY_WRITTEN
-                )
+                self.assertIn(messages.REPORT_SUCCESSFULLY_WRITTEN, log.output[-1])
 
     # Test validation
     def test_insights_report_output_directory(self):
@@ -178,7 +170,6 @@ class ReportInsightsTests(unittest.TestCase):
     def test_insights_file_fails_to_write(self, file):
         """Testing insights failure while writing to file."""
         file.side_effect = EnvironmentError()
-        report_out = StringIO()
         get_report_url = get_server_location() + REPORT_URI + "1/insights/"
         get_report_json_data = {"id": 1, "report": [{"key": "value"}]}
         test_dict = {self.test_tar_gz_filename: get_report_json_data}
@@ -194,11 +185,11 @@ class ReportInsightsTests(unittest.TestCase):
             args = Namespace(
                 scan_job_id=None, report_id="1", path=self.test_tar_gz_filename
             )
-            with redirect_stdout(report_out):
+            with self.assertLogs(level="ERROR") as log:
                 with self.assertRaises(SystemExit):
                     nac.main(args)
                 err_msg = messages.WRITE_FILE_ERROR % (self.test_tar_gz_filename, "")
-                self.assertEqual(report_out.getvalue().strip(), err_msg)
+                self.assertIn(err_msg, log.output[0])
 
     def test_insights_nonexistent_directory(self):
         """Testing error for nonexistent directory in output."""

--- a/qpc/utils.py
+++ b/qpc/utils.py
@@ -499,12 +499,15 @@ def write_file(filename, content, binary=False):
     :raises: EnvironmentError if file cannot be written
     """
     result = None
-    input_path = os.path.expanduser(os.path.expandvars(filename))
-    mode = "w"
-    if binary:
-        mode = "wb"
-    with open(input_path, mode) as out_file:  # pylint: disable=unspecified-encoding
-        out_file.write(content)
+    if filename is None:
+        print(content)
+    else:
+        input_path = os.path.expanduser(os.path.expandvars(filename))
+        mode = "w"
+        if binary:
+            mode = "wb"
+        with open(input_path, mode) as out_file:  # pylint: disable=unspecified-encoding
+            out_file.write(content)
     return result
 
 
@@ -551,6 +554,8 @@ def create_tar_buffer(files_data):
 
 def check_extension(extension, path):
     """Check if .json is in the file extension."""
+    if path is None:
+        return
     if extension not in path:
         print(t(messages.OUTPUT_FILE_TYPE % extension))
         sys.exit(1)


### PR DESCRIPTION
Output files won't be required for deployments and details 
reports, content will be written to stdout as default when the user
choose json file format.
For insights reports, the behavior will be the same except for a little detail, the --json flag won't be necessary, the json report will be directly written to the stdout. 

This implements [[DISCOVERY-184]](https://issues.redhat.com/browse/DISCOVERY-184)