### PR TITLE
Display qpc error messages to user

### DIFF
--- a/qpc/utils.py
+++ b/qpc/utils.py
@@ -369,7 +369,9 @@ def setup_logging(verbosity):
         # (at least until we add an option controlling the log format)
         stream_handler.setFormatter(logging.Formatter(log_fmt))
     stream_handler.setLevel(log_level)
-    logger.addHandler(stream_handler)
+    main_package_name, *_ = __name__.partition(".")
+    global_logger = logging.getLogger(main_package_name)
+    global_logger.addHandler(stream_handler)
 
 
 def log_request_info(method, command, url, response_json, response_code):


### PR DESCRIPTION
#222 / 64bd49e7 attempted to unify logging, but had one unintended consequence - StreamHandler was added only to `qpc.utils` logger. That logger is imported by some other modules, like `qpc.request`, so things appeared to work as expected - calling `qpc -v` would display some debugging messages on terminal, and everything outside of `qpc` could be found in log file.

However, since mostly everything else is using `logging.getLogger(__name__)`, messages clearly meant to be displayed to user also ended up only in log file. Example:

```
$ qpc  cred edit  --name='this doesnt exist no really it doesnt' --password
$   # nothing was displayed
```

["Credential "%s" does not exist." should be displayed](https://github.com/quipucords/qpc/blob/master/qpc/cred/edit.py#L134), but since this logger is `qpc.cred.edit`, this message is only handled by [basicConfig setup](https://github.com/quipucords/qpc/blob/master/qpc/utils.py#L364) and redirected to log file.

With this PR, `setup_logging` will add `StreamHandler` to top-level package logger (`qpc`). As a result, all `logger.error()` calls are going to be displayed to user. They will also be included in log file. All messages coming from outside of `qpc` are still present in log file.