### PR TITLE
fix: api calls should not appear with verbosity 1

### DIFF
--- a/qpc/cred/test_openshift_cred_add.py
+++ b/qpc/cred/test_openshift_cred_add.py
@@ -132,3 +132,28 @@ class TestOpenShiftAddCredential:
         ]
         CLI().main()
         assert caplog.messages[-1] == messages.CRED_ADDED % "openshift_credential"
+
+    def test_no_api_info_shown_with_verbose_flag(
+        self,
+        caplog,
+        requests_mock,
+        openshift_token_input
+    ):
+        """Test that no API information is shown when the -v flag is used."""
+        caplog.set_level("INFO")
+        url = get_server_location() + CREDENTIAL_URI
+        requests_mock.post(url, status_code=201)
+        sys.argv = [
+            "/bin/qpc",
+            "-v",
+            "cred",
+            "add",
+            "--name",
+            "openshift_credential",
+            "--type",
+            "openshift",
+            "--token",
+        ]
+        CLI().main()
+        for message in caplog.messages:
+            assert "POST" not in message

--- a/qpc/utils.py
+++ b/qpc/utils.py
@@ -385,7 +385,7 @@ def log_request_info(method, command, url, response_json, response_code):
     :param response_code: the status code being returned (ie. 200)
     """
     message = 'Method: "%s", Command: "%s", URL: "%s", Response: "%s", Status Code: "%s'
-    logger.info(message, method, command, url, response_json, response_code)
+    logger.debug(message, method, command, url, response_json, response_code)
 
 
 def log_args(args):


### PR DESCRIPTION
API calls should only appear when log verbosity >= 2.