### PR TITLE
fix: stop storing binary responses in qpc.log

### DIFF
--- a/qpc/request.py
+++ b/qpc/request.py
@@ -204,8 +204,8 @@ def request(
         sys.exit(1)
 
     log_request_info(
-                method, log_command, url, result.json(), result.status_code
-            )
+        method, log_command, url, decode_response_json(result), result.status_code
+    )
     return result
 
 
@@ -246,3 +246,11 @@ def perform_request(
     return handle_general_errors(
         request_method(url, payload, req_headers), min_server_version
     )
+
+
+def decode_response_json(response):
+    """Return either a json or text to avoid saving binary to logs."""
+    try:
+        return response.json()
+    except ValueError:
+        return "<encoded blob ignored>"

--- a/qpc/test_request.py
+++ b/qpc/test_request.py
@@ -1,0 +1,61 @@
+"""QPC request tests."""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from qpc.request import request
+
+
+def test_request_invalid_method(server_config, caplog):
+    """Test request with an invalid http method."""
+    caplog.set_level("ERROR")
+    parser_mock = MagicMock()
+    with pytest.raises(SystemExit):
+        with patch('builtins.print'):
+            with patch('argparse.ArgumentParser.print_help'):
+                request('INVALID_METHOD', '/path', parser=parser_mock)
+    assert caplog.messages[-1] == 'Unsupported request method INVALID_METHOD'
+
+
+@pytest.mark.parametrize(
+    "method", ["GET", "DELETE", "PUT", "POST", "PATCH"]
+)
+def test_request_methods(server_config, method):
+    """Test request with valid http methods."""
+    with patch("qpc.request.perform_request") as mock_perform_request:
+        request(method, "/path")
+        mock_perform_request.assert_called_once_with(
+            method,
+            'http://127.0.0.1:8000/path',
+            None,
+            None,
+            {},
+            '0.9.0',
+        )
+
+
+def test_log_request_info_invalid_json(server_config, caplog):
+    """Test log_request_info with invalid json."""
+    caplog.set_level("DEBUG")
+    response = MagicMock()
+    response.status_code = 200
+    response.json.side_effect = ValueError("Invalid JSON")
+
+    with patch("qpc.request.perform_request", return_value=response):
+        request("GET", "/path")
+
+    assert 'Response: "<encoded blob ignored>"' in caplog.messages[-1]
+
+
+def test_log_request_info_valid_json(server_config, caplog):
+    """Test log_request_info with valid json."""
+    caplog.set_level("DEBUG")
+    response = MagicMock()
+    response.status_code = 200
+    response.json.return_value = {"message": "Success"}
+
+    with patch("qpc.request.perform_request", return_value=response):
+        request("GET", "/path")
+
+    assert 'Response: "{\'message\': \'Success\'}"' in caplog.messages[-1]

--- a/qpc/test_utils.py
+++ b/qpc/test_utils.py
@@ -1,4 +1,5 @@
 """Test qpc cred utils."""
+
 import pytest
 
 from qpc.messages import PROMPT_INPUT


### PR DESCRIPTION
Any binaries received in response_json that can be converted to json will be stored, otherwise replaced by "encoded blob ignored"