### PR TITLE
fix: improve acceptable arg options text

### DIFF
--- a/qpc/source/__init__.py
+++ b/qpc/source/__init__.py
@@ -22,5 +22,5 @@ SOURCE_TYPE_CHOICES = [
     VCENTER_SOURCE_TYPE,
 ]
 
-BOOLEAN_CHOICES = ["True", "False", "true", "false"]
+BOOLEAN_CHOICES = ["true", "false"]
 VALID_SSL_PROTOCOLS = ["SSLv23", "TLSv1", "TLSv1_1", "TLSv1_2"]

--- a/qpc/source/add.py
+++ b/qpc/source/add.py
@@ -113,6 +113,7 @@ class SourceAddCommand(CliCommand):
             "--use-paramiko",
             dest="use_paramiko",
             choices=source.BOOLEAN_CHOICES,
+            type=str.lower,
             help=_(messages.SOURCE_PARAMIKO_HELP),
             required=False,
         )

--- a/qpc/source/edit.py
+++ b/qpc/source/edit.py
@@ -106,6 +106,7 @@ class SourceEditCommand(CliCommand):
             "--use-paramiko",
             dest="use_paramiko",
             choices=source.BOOLEAN_CHOICES,
+            type=str.lower,
             help=_(messages.SOURCE_PARAMIKO_HELP),
             required=False,
         )


### PR DESCRIPTION
The fields in which this text is being used were not case insensitive in the past, therefore needed a more explicit description on accepted values. A recent refactor modified this behavior.

This implements [[DISCOVERY-206]](https://issues.redhat.com/browse/DISCOVERY-206)