### PR TITLE
chore: Updating qpc cli and man page version to reflect the poetry package version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,7 @@
 DATE		= $(shell date)
 PYTHON		= $(shell which python)
+PKG_VERSION = $(shell poetry -s version)
+BUILD_DATE  = $(shell date +'%B %d, %Y')
 
 TOPDIR = $(shell pwd)
 DIRS	= test bin locale src
@@ -60,8 +62,8 @@ manpage:
 	$(pandoc) docs/source/man.rst \
 	  --standalone -t man -o docs/qpc.1 \
 	  --variable=section:1 \
-	  --variable=date:'June 6, 2019' \
-	  --variable=footer:'version 3' \
+	  --variable=date:'$(BUILD_DATE)' \
+	  --variable=footer:'version $(PKG_VERSION)' \
 	  --variable=header:'QPC Command Line Guide'
 
 insights-client:

--- a/qpc/__init__.py
+++ b/qpc/__init__.py
@@ -1,0 +1,6 @@
+"""QPC Package Initialization."""
+from importlib import metadata
+
+# Let's get the package version from poetry
+__package__version__ = metadata.version(__package__)
+del metadata

--- a/qpc/release.py
+++ b/qpc/release.py
@@ -1,5 +1,7 @@
 """File to hold release constants."""
-VERSION = "1.0.1"
+from . import __package__version__
+
+VERSION = __package__version__
 AUTHOR = "QPC Team"
 AUTHOR_EMAIL = "qpc@redhat.com"
 PKG_NAME = "qpc"


### PR DESCRIPTION
chore: Updating qpc cli and man page version to reflect the poetry package version

- poetry run qpc --version
- deploy/qpc man qpc

Both return the poetry -s version (currently 1.2.2) which is what gets tagged in github.com/quipucords/qpc.