### PR TITLE
test: adjust tests for python 3.11

### DIFF
--- a/qpc/cred/tests_cred_add.py
+++ b/qpc/cred/tests_cred_add.py
@@ -23,12 +23,17 @@ from qpc.tests_utilities import DEFAULT_CONFIG, HushUpStderr, redirect_stdout
 from qpc.utils import get_server_location, write_server_config
 
 TMP_KEY = "/tmp/testkey"
-PARSER = ArgumentParser()
-SUBPARSER = PARSER.add_subparsers(dest="subcommand")
 
 
 class CredentialAddCliTests(unittest.TestCase):
     """Class for testing the credential add commands for qpc."""
+
+    @classmethod
+    def setUpClass(cls):
+        """Set up test case."""
+        argument_parser = ArgumentParser()
+        subparser = argument_parser.add_subparsers(dest="subcommand")
+        cls.command = CredAddCommand(subparser)
 
     def setUp(self):
         """Create test setup."""
@@ -98,7 +103,6 @@ class CredentialAddCliTests(unittest.TestCase):
         error = {"name": ["credential with this name already exists."]}
         with requests_mock.Mocker() as mocker:
             mocker.post(url, status_code=400, json=error)
-            cred_add = CredAddCommand(SUBPARSER)
             args = Namespace(
                 name="cred_dup",
                 username="root",
@@ -110,8 +114,7 @@ class CredentialAddCliTests(unittest.TestCase):
             )
             with self.assertRaises(SystemExit):
                 with redirect_stdout(cred_out):
-                    cred_add.main(args)
-                    cred_add.main(args)
+                    self.command.main(args)
 
     def test_add_cred_ssl_err(self):
         """Testing the add credential command with a connection error."""
@@ -119,7 +122,6 @@ class CredentialAddCliTests(unittest.TestCase):
         url = get_server_location() + CREDENTIAL_URI
         with requests_mock.Mocker() as mocker:
             mocker.post(url, exc=requests.exceptions.SSLError)
-            cred_add = CredAddCommand(SUBPARSER)
             args = Namespace(
                 name="credential1",
                 username="root",
@@ -131,7 +133,7 @@ class CredentialAddCliTests(unittest.TestCase):
             )
             with self.assertRaises(SystemExit):
                 with redirect_stdout(cred_out):
-                    cred_add.main(args)
+                    self.command.main(args)
 
     def test_add_cred_conn_err(self):
         """Testing the add credential command with a connection error."""
@@ -139,7 +141,6 @@ class CredentialAddCliTests(unittest.TestCase):
         url = get_server_location() + CREDENTIAL_URI
         with requests_mock.Mocker() as mocker:
             mocker.post(url, exc=requests.exceptions.ConnectTimeout)
-            cred_add = CredAddCommand(SUBPARSER)
             args = Namespace(
                 name="credential1",
                 username="root",
@@ -151,14 +152,13 @@ class CredentialAddCliTests(unittest.TestCase):
             )
             with self.assertRaises(SystemExit):
                 with redirect_stdout(cred_out):
-                    cred_add.main(args)
+                    self.command.main(args)
 
     def test_add_host_cred(self):
         """Testing the add host cred command successfully."""
         url = get_server_location() + CREDENTIAL_URI
         with requests_mock.Mocker() as mocker:
             mocker.post(url, status_code=201)
-            cred_add = CredAddCommand(SUBPARSER)
             args = Namespace(
                 name="credential1",
                 username="root",
@@ -171,7 +171,7 @@ class CredentialAddCliTests(unittest.TestCase):
                 become_password=None,
             )
             with self.assertLogs(level="INFO") as log:
-                cred_add.main(args)
+                self.command.main(args)
                 expected_message = messages.CRED_ADDED % "credential1"
                 self.assertIn(expected_message, log.output[-1])
 
@@ -180,7 +180,6 @@ class CredentialAddCliTests(unittest.TestCase):
         url = get_server_location() + CREDENTIAL_URI
         with requests_mock.Mocker() as mocker:
             mocker.post(url, status_code=201)
-            cred_add = CredAddCommand(SUBPARSER)
             args = Namespace(
                 name="credential1",
                 username="root",
@@ -193,7 +192,7 @@ class CredentialAddCliTests(unittest.TestCase):
                 become_password=None,
             )
             with self.assertLogs(level="INFO") as log:
-                cred_add.main(args)
+                self.command.main(args)
                 expected_message = messages.CRED_ADDED % "credential1"
                 self.assertIn(expected_message, log.output[-1])
 
@@ -203,7 +202,6 @@ class CredentialAddCliTests(unittest.TestCase):
         url = get_server_location() + CREDENTIAL_URI
         with requests_mock.Mocker() as mocker:
             mocker.post(url, status_code=201)
-            cred_add = CredAddCommand(SUBPARSER)
             args = Namespace(
                 name="credential1",
                 type=VCENTER_CRED_TYPE,
@@ -212,7 +210,7 @@ class CredentialAddCliTests(unittest.TestCase):
             )
             do_mock_raw_input.return_value = "abc"
             with self.assertLogs(level="INFO") as log:
-                cred_add.main(args)
+                self.command.main(args)
                 expected_message = messages.CRED_ADDED % "credential1"
                 self.assertIn(expected_message, log.output[-1])
 
@@ -222,7 +220,6 @@ class CredentialAddCliTests(unittest.TestCase):
         url = get_server_location() + CREDENTIAL_URI
         with requests_mock.Mocker() as mocker:
             mocker.post(url, status_code=201)
-            cred_add = CredAddCommand(SUBPARSER)
             args = Namespace(
                 name="credential1",
                 type=SATELLITE_CRED_TYPE,
@@ -231,7 +228,7 @@ class CredentialAddCliTests(unittest.TestCase):
             )
             do_mock_raw_input.return_value = "abc"
             with self.assertLogs(level="INFO") as log:
-                cred_add.main(args)
+                self.command.main(args)
                 expected_message = messages.CRED_ADDED % "credential1"
                 self.assertIn(expected_message, log.output[-1])
 
@@ -242,7 +239,6 @@ class CredentialAddCliTests(unittest.TestCase):
         url = get_server_location() + CREDENTIAL_URI
         with requests_mock.Mocker() as mocker:
             mocker.post(url, status_code=401)
-            cred_add = CredAddCommand(SUBPARSER)
             args = Namespace(
                 name="credential1",
                 type=SATELLITE_CRED_TYPE,
@@ -252,7 +248,7 @@ class CredentialAddCliTests(unittest.TestCase):
             do_mock_raw_input.return_value = "abc"
             with self.assertRaises(SystemExit):
                 with redirect_stdout(cred_out):
-                    cred_add.main(args)
+                    self.command.main(args)
 
     @patch("getpass._raw_input")
     def test_add_cred_expired(self, do_mock_raw_input):
@@ -262,7 +258,6 @@ class CredentialAddCliTests(unittest.TestCase):
         with requests_mock.Mocker() as mocker:
             expired = {"detail": "Token has expired"}
             mocker.post(url, status_code=400, json=expired)
-            cred_add = CredAddCommand(SUBPARSER)
             args = Namespace(
                 name="credential1",
                 type=SATELLITE_CRED_TYPE,
@@ -272,4 +267,4 @@ class CredentialAddCliTests(unittest.TestCase):
             do_mock_raw_input.return_value = "abc"
             with self.assertRaises(SystemExit):
                 with redirect_stdout(cred_out):
-                    cred_add.main(args)
+                    self.command.main(args)

--- a/qpc/cred/tests_cred_clear.py
+++ b/qpc/cred/tests_cred_clear.py
@@ -13,12 +13,16 @@ from qpc.cred.clear import CredClearCommand
 from qpc.tests_utilities import DEFAULT_CONFIG, HushUpStderr, redirect_stdout
 from qpc.utils import get_server_location, write_server_config
 
-PARSER = ArgumentParser()
-SUBPARSER = PARSER.add_subparsers(dest="subcommand")
-
 
 class CredentialClearCliTests(unittest.TestCase):
     """Class for testing the credential clear commands for qpc."""
+
+    @classmethod
+    def setUpClass(cls):
+        """Set up test case."""
+        argument_parser = ArgumentParser()
+        subparser = argument_parser.add_subparsers(dest="subcommand")
+        cls.command = CredClearCommand(subparser)
 
     def setUp(self):
         """Create test setup."""
@@ -39,11 +43,10 @@ class CredentialClearCliTests(unittest.TestCase):
         url = get_server_location() + CREDENTIAL_URI + "?name=credential1"
         with requests_mock.Mocker() as mocker:
             mocker.get(url, exc=requests.exceptions.SSLError)
-            cred_clear = CredClearCommand(SUBPARSER)
             args = Namespace(name="credential1")
             with self.assertRaises(SystemExit):
                 with redirect_stdout(cred_out):
-                    cred_clear.main(args)
+                    self.command.main(args)
 
     def test_clear_cred_conn_err(self):
         """Testing the clear credential command with a connection error."""
@@ -51,11 +54,10 @@ class CredentialClearCliTests(unittest.TestCase):
         url = get_server_location() + CREDENTIAL_URI + "?name=credential1"
         with requests_mock.Mocker() as mocker:
             mocker.get(url, exc=requests.exceptions.ConnectTimeout)
-            cred_clear = CredClearCommand(SUBPARSER)
             args = Namespace(name="credential1")
             with self.assertRaises(SystemExit):
                 with redirect_stdout(cred_out):
-                    cred_clear.main(args)
+                    self.command.main(args)
 
     def test_clear_cred_internal_err(self):
         """Testing the clear credential command with an internal error."""
@@ -63,11 +65,10 @@ class CredentialClearCliTests(unittest.TestCase):
         url = get_server_location() + CREDENTIAL_URI + "?name=credential1"
         with requests_mock.Mocker() as mocker:
             mocker.get(url, status_code=500, json={"error": ["Server Error"]})
-            cred_clear = CredClearCommand(SUBPARSER)
             args = Namespace(name="credential1")
             with self.assertRaises(SystemExit):
                 with redirect_stdout(cred_out):
-                    cred_clear.main(args)
+                    self.command.main(args)
 
     def test_clear_cred_empty(self):
         """Testing the clear credential command with empty data."""
@@ -75,11 +76,10 @@ class CredentialClearCliTests(unittest.TestCase):
         url = get_server_location() + CREDENTIAL_URI + "?name=cred1"
         with requests_mock.Mocker() as mocker:
             mocker.get(url, status_code=200, json={"count": 0})
-            cred_clear = CredClearCommand(SUBPARSER)
             args = Namespace(name="cred1")
             with self.assertRaises(SystemExit):
                 with redirect_stdout(cred_out):
-                    cred_clear.main(args)
+                    self.command.main(args)
 
     def test_clear_by_name(self):
         """Testing the clear credential command with stubbed data."""
@@ -96,10 +96,9 @@ class CredentialClearCliTests(unittest.TestCase):
         with requests_mock.Mocker() as mocker:
             mocker.get(get_url, status_code=200, json=data)
             mocker.delete(delete_url, status_code=204)
-            cred_clear = CredClearCommand(SUBPARSER)
             args = Namespace(name="credential1")
             with self.assertLogs(level="INFO") as log:
-                cred_clear.main(args)
+                self.command.main(args)
                 expected_message = messages.CRED_REMOVED % "credential1"
                 self.assertIn(expected_message, log.output[-1])
 
@@ -123,11 +122,10 @@ class CredentialClearCliTests(unittest.TestCase):
         with requests_mock.Mocker() as mocker:
             mocker.get(get_url, status_code=200, json=data)
             mocker.delete(delete_url, status_code=500, json=err_data)
-            cred_clear = CredClearCommand(SUBPARSER)
             args = Namespace(name="credential1")
             with self.assertRaises(SystemExit):
                 with redirect_stdout(cred_out):
-                    cred_clear.main(args)
+                    self.command.main(args)
 
     def test_clear_all_empty(self):
         """Testing the clear credential command successfully with stubbed data.
@@ -138,11 +136,10 @@ class CredentialClearCliTests(unittest.TestCase):
         get_url = get_server_location() + CREDENTIAL_URI
         with requests_mock.Mocker() as mocker:
             mocker.get(get_url, status_code=200, json={"count": 0})
-            cred_clear = CredClearCommand(SUBPARSER)
             args = Namespace(name=None)
             with self.assertRaises(SystemExit):
                 with redirect_stdout(cred_out):
-                    cred_clear.main(args)
+                    self.command.main(args)
 
     def test_clear_all_with_error(self):
         """Testing the clear credential command successfully with stubbed data.
@@ -163,10 +160,9 @@ class CredentialClearCliTests(unittest.TestCase):
         with requests_mock.Mocker() as mocker:
             mocker.get(get_url, status_code=200, json=data)
             mocker.delete(delete_url, status_code=500, json=err_data)
-            cred_clear = CredClearCommand(SUBPARSER)
             args = Namespace(name=None)
             with self.assertRaises(SystemExit):
-                cred_clear.main(args)
+                self.command.main(args)
 
     def test_clear_all(self):
         """Testing the clear credential command successfully with stubbed data.
@@ -186,9 +182,8 @@ class CredentialClearCliTests(unittest.TestCase):
         with requests_mock.Mocker() as mocker:
             mocker.get(get_url, status_code=200, json=data)
             mocker.delete(delete_url, status_code=204)
-            cred_clear = CredClearCommand(SUBPARSER)
             args = Namespace(name=None)
             with self.assertLogs(level="INFO") as log:
-                cred_clear.main(args)
+                self.command.main(args)
                 expected_message = messages.CRED_CLEAR_ALL_SUCCESS
                 self.assertIn(expected_message, log.output[-1])

--- a/qpc/cred/tests_cred_show.py
+++ b/qpc/cred/tests_cred_show.py
@@ -13,12 +13,16 @@ from qpc.cred.show import CredShowCommand
 from qpc.tests_utilities import DEFAULT_CONFIG, HushUpStderr, redirect_stdout
 from qpc.utils import get_server_location, write_server_config
 
-PARSER = ArgumentParser()
-SUBPARSER = PARSER.add_subparsers(dest="subcommand")
-
 
 class CredentialShowCliTests(unittest.TestCase):
     """Class for testing the credential show commands for qpc."""
+
+    @classmethod
+    def setUpClass(cls):
+        """Set up test case."""
+        argument_parser = ArgumentParser()
+        subparser = argument_parser.add_subparsers(dest="subcommand")
+        cls.command = CredShowCommand(subparser)
 
     def setUp(self):
         """Create test setup."""
@@ -39,11 +43,11 @@ class CredentialShowCliTests(unittest.TestCase):
         url = get_server_location() + CREDENTIAL_URI + "?name=credential1"
         with requests_mock.Mocker() as mocker:
             mocker.get(url, exc=requests.exceptions.SSLError)
-            csc = CredShowCommand(SUBPARSER)
+
             args = Namespace(name="credential1")
             with self.assertRaises(SystemExit):
                 with redirect_stdout(cred_out):
-                    csc.main(args)
+                    self.command.main(args)
 
     def test_show_cred_conn_err(self):
         """Testing the show credential command with a connection error."""
@@ -51,11 +55,11 @@ class CredentialShowCliTests(unittest.TestCase):
         url = get_server_location() + CREDENTIAL_URI + "?name=credential1"
         with requests_mock.Mocker() as mocker:
             mocker.get(url, exc=requests.exceptions.ConnectTimeout)
-            csc = CredShowCommand(SUBPARSER)
+
             args = Namespace(name="credential1")
             with self.assertRaises(SystemExit):
                 with redirect_stdout(cred_out):
-                    csc.main(args)
+                    self.command.main(args)
 
     def test_show_cred_internal_err(self):
         """Testing the show credential command with an internal error."""
@@ -63,11 +67,11 @@ class CredentialShowCliTests(unittest.TestCase):
         url = get_server_location() + CREDENTIAL_URI + "?name=credential1"
         with requests_mock.Mocker() as mocker:
             mocker.get(url, status_code=500, json={"error": ["Server Error"]})
-            csc = CredShowCommand(SUBPARSER)
+
             args = Namespace(name="credential1")
             with self.assertRaises(SystemExit):
                 with redirect_stdout(cred_out):
-                    csc.main(args)
+                    self.command.main(args)
 
     def test_show_cred_empty(self):
         """Testing the show credential command successfully with empty data."""
@@ -75,11 +79,11 @@ class CredentialShowCliTests(unittest.TestCase):
         url = get_server_location() + CREDENTIAL_URI + "?name=cred1"
         with requests_mock.Mocker() as mocker:
             mocker.get(url, status_code=200, json={"count": 0})
-            csc = CredShowCommand(SUBPARSER)
+
             args = Namespace(name="cred1")
             with self.assertRaises(SystemExit):
                 with redirect_stdout(cred_out):
-                    csc.main(args)
+                    self.command.main(args)
 
     def test_show_cred_data(self):
         """Testing the show credential command with stubbed data."""
@@ -95,10 +99,10 @@ class CredentialShowCliTests(unittest.TestCase):
         data = {"count": 1, "results": results}
         with requests_mock.Mocker() as mocker:
             mocker.get(url, status_code=200, json=data)
-            csc = CredShowCommand(SUBPARSER)
+
             args = Namespace(name="cred1")
             with redirect_stdout(cred_out):
-                csc.main(args)
+                self.command.main(args)
                 expected = (
                     '{"id":1,"name":"cred1","password":"********","username":"root"}'
                 )

--- a/qpc/report/tests_report_insights.py
+++ b/qpc/report/tests_report_insights.py
@@ -19,17 +19,25 @@ from qpc.scan import SCAN_JOB_URI
 from qpc.tests_utilities import DEFAULT_CONFIG, HushUpStderr, redirect_stdout
 from qpc.utils import create_tar_buffer, get_server_location, write_server_config
 
-PARSER = ArgumentParser()
-SUBPARSER = PARSER.add_subparsers(dest="subcommand")
 VERSION = "0.9.4"
 
 
 class ReportInsightsTests(unittest.TestCase):
     """Class for testing the insights report command."""
 
-    # pylint: disable=invalid-name
-    def setUp(self):
+    def _init_command(self):
+        """Initialize command."""
+        argument_parser = ArgumentParser()
+        subparser = argument_parser.add_subparsers(dest="subcommand")
+        return ReportInsightsCommand(subparser)
+
+    def setUp(self):  # pylint: disable=invalid-name
         """Create test setup."""
+        # different from most other test cases where command is initialized once per
+        # class, this one requires to be initialized for each test method because
+        # SourceEditCommand instance modifies req_path on the fly. This seems to be a
+        # code smell to me, but I'm choosing to ignore it for now
+        self.command = self._init_command()
         write_server_config(DEFAULT_CONFIG)
         # Temporarily disable stderr for these tests, CLI errors clutter up
         # nosetests command.
@@ -67,12 +75,12 @@ class ReportInsightsTests(unittest.TestCase):
                 headers={"X-Server-Version": VERSION},
                 content=buffer_content,
             )
-            nac = ReportInsightsCommand(SUBPARSER)
+
             args = Namespace(
                 scan_job_id="1", report_id=None, path=self.test_tar_gz_filename
             )
             with self.assertLogs(level="INFO") as log:
-                nac.main(args)
+                self.command.main(args)
                 self.assertIn(messages.REPORT_SUCCESSFULLY_WRITTEN, log.output[-1])
 
     def test_insights_report_as_json_report_id(self):
@@ -92,12 +100,12 @@ class ReportInsightsTests(unittest.TestCase):
                 headers={"X-Server-Version": VERSION},
                 content=buffer_content,
             )
-            nac = ReportInsightsCommand(SUBPARSER)
+
             args = Namespace(
                 scan_job_id=None, report_id="1", path=self.test_tar_gz_filename
             )
             with self.assertLogs(level="INFO") as log:
-                nac.main(args)
+                self.command.main(args)
                 self.assertIn(messages.REPORT_SUCCESSFULLY_WRITTEN, log.output[-1])
 
     # Test validation
@@ -127,13 +135,13 @@ class ReportInsightsTests(unittest.TestCase):
         get_scanjob_json_data = {"id": 1, "report_id": 1}
         with requests_mock.Mocker() as mocker:
             mocker.get(get_scanjob_url, status_code=400, json=get_scanjob_json_data)
-            nac = ReportInsightsCommand(SUBPARSER)
+
             args = Namespace(
                 scan_job_id="1", report_id=None, path=self.test_tar_gz_filename
             )
             with self.assertRaises(SystemExit):
                 with redirect_stdout(report_out):
-                    nac.main(args)
+                    self.command.main(args)
                     self.assertEqual(
                         report_out.getvalue(), messages.REPORT_SJ_DOES_NOT_EXIST
                     )
@@ -146,13 +154,13 @@ class ReportInsightsTests(unittest.TestCase):
         get_scanjob_json_data = {"id": 1}
         with requests_mock.Mocker() as mocker:
             mocker.get(get_scanjob_url, status_code=200, json=get_scanjob_json_data)
-            nac = ReportInsightsCommand(SUBPARSER)
+
             args = Namespace(
                 scan_job_id="1", report_id=None, path=self.test_tar_gz_filename
             )
             with self.assertRaises(SystemExit):
                 with redirect_stdout(report_out):
-                    nac.main(args)
+                    self.command.main(args)
                     self.assertEqual(
                         report_out.getvalue(),
                         messages.REPORT_NO_DEPLOYMENTS_REPORT_FOR_SJ,
@@ -173,13 +181,13 @@ class ReportInsightsTests(unittest.TestCase):
                 headers={"X-Server-Version": VERSION},
                 content=buffer_content,
             )
-            nac = ReportInsightsCommand(SUBPARSER)
+
             args = Namespace(
                 scan_job_id=None, report_id="1", path=self.test_tar_gz_filename
             )
             with self.assertLogs(level="ERROR") as log:
                 with self.assertRaises(SystemExit):
-                    nac.main(args)
+                    self.command.main(args)
                 err_msg = messages.WRITE_FILE_ERROR % {
                     "path": self.test_tar_gz_filename,
                     "error": "",
@@ -195,11 +203,11 @@ class ReportInsightsTests(unittest.TestCase):
         buffer_content = create_tar_buffer(test_dict)
         with requests_mock.Mocker() as mocker:
             mocker.get(get_report_url, status_code=200, content=buffer_content)
-            nac = ReportInsightsCommand(SUBPARSER)
+
             args = Namespace(scan_job_id=None, report_id="1", path=fake_dir)
             with self.assertLogs(level="ERROR") as log:
                 with self.assertRaises(SystemExit):
-                    nac.main(args)
+                    self.command.main(args)
                 err_msg = messages.REPORT_DIRECTORY_DOES_NOT_EXIST % os.path.dirname(
                     fake_dir
                 )
@@ -219,11 +227,11 @@ class ReportInsightsTests(unittest.TestCase):
                 headers={"X-Server-Version": VERSION},
                 content=buffer_content,
             )
-            nac = ReportInsightsCommand(SUBPARSER)
+
             args = Namespace(scan_job_id=None, report_id="1", path=non_tar_file)
             with self.assertLogs(level="ERROR") as log:
                 with self.assertRaises(SystemExit):
-                    nac.main(args)
+                    self.command.main(args)
                 err_msg = messages.OUTPUT_FILE_TYPE % "tar.gz"
                 self.assertIn(err_msg, log.output[0])
 
@@ -240,13 +248,13 @@ class ReportInsightsTests(unittest.TestCase):
                 headers={"X-Server-Version": VERSION},
                 content=buffer_content,
             )
-            nac = ReportInsightsCommand(SUBPARSER)
+
             args = Namespace(
                 scan_job_id=None, report_id="1", path=self.test_tar_gz_filename
             )
             with self.assertLogs(level="ERROR") as log:
                 with self.assertRaises(SystemExit):
-                    nac.main(args)
+                    self.command.main(args)
                 err_msg = messages.REPORT_NO_INSIGHTS_REPORT_FOR_REPORT_ID % 1
                 self.assertIn(err_msg, log.output[0])
 
@@ -266,13 +274,13 @@ class ReportInsightsTests(unittest.TestCase):
                 headers={"X-Server-Version": VERSION},
                 content=buffer_content,
             )
-            nac = ReportInsightsCommand(SUBPARSER)
+
             args = Namespace(
                 scan_job_id="1", report_id=None, path=self.test_tar_gz_filename
             )
             with self.assertLogs(level="ERROR") as log:
                 with self.assertRaises(SystemExit):
-                    nac.main(args)
+                    self.command.main(args)
                 err_msg = messages.REPORT_NO_INSIGHTS_REPORT_FOR_SJ % 1
                 self.assertIn(err_msg, log.output[0])
 

--- a/qpc/report/tests_report_merge.py
+++ b/qpc/report/tests_report_merge.py
@@ -61,12 +61,17 @@ JSON_FILES_LIST = [
     TMP_GOODDETAILS,
     TMP_BADDETAILS5,
 ]
-PARSER = ArgumentParser()
-SUBPARSER = PARSER.add_subparsers(dest="subcommand")
 
 
 class ReportMergeTests(unittest.TestCase):
     """Class for testing the scan show commands for qpc."""
+
+    @classmethod
+    def setUpClass(cls):
+        """Set up test case."""
+        argument_parser = ArgumentParser()
+        subparser = argument_parser.add_subparsers(dest="subcommand")
+        cls.command = ReportMergeCommand(subparser)
 
     # pylint: disable=invalid-name
     def setUp(self):
@@ -113,11 +118,11 @@ class ReportMergeTests(unittest.TestCase):
             mocker.get(get_scanjob1_url, status_code=200, json=scanjob1_data)
             mocker.get(get_scanjob2_url, status_code=200, json=scanjob2_data)
             mocker.put(put_merge_url, status_code=201, json=put_report_data)
-            nac = ReportMergeCommand(SUBPARSER)
+
             args = Namespace(
                 scan_job_ids=[1, 2], json_files=None, report_ids=None, json_dir=None
             )
-            nac.main(args)
+            self.command.main(args)
             expected_msg = messages.REPORT_SUCCESSFULLY_MERGED % {
                 "id": "1",
                 "pkg_name": PKG_NAME,
@@ -139,13 +144,13 @@ class ReportMergeTests(unittest.TestCase):
             mocker.get(get_scanjob1_url, status_code=200, json=scanjob1_data)
             mocker.get(get_scanjob2_url, status_code=200, json=scanjob2_data)
             mocker.put(put_merge_url, status_code=400, json=put_report_data)
-            nac = ReportMergeCommand(SUBPARSER)
+
             args = Namespace(
                 scan_job_ids=[1, 2], json_files=None, report_ids=None, json_dir=None
             )
             with self.assertRaises(SystemExit):
                 with redirect_stdout(report_out):
-                    nac.main(args)
+                    self.command.main(args)
 
     def test_detail_merge_report_ids(self):
         """Testing report merge command with report ids."""
@@ -154,11 +159,11 @@ class ReportMergeTests(unittest.TestCase):
         captured_stdout = StringIO()
         with requests_mock.Mocker() as mocker, redirect_stdout(captured_stdout):
             mocker.put(put_merge_url, status_code=201, json=put_report_data)
-            nac = ReportMergeCommand(SUBPARSER)
+
             args = Namespace(
                 scan_job_ids=None, json_files=None, report_ids=[1, 2], json_dir=None
             )
-            nac.main(args)
+            self.command.main(args)
             expected_msg = messages.REPORT_SUCCESSFULLY_MERGED % {
                 "id": "1",
                 "pkg_name": PKG_NAME,
@@ -174,13 +179,13 @@ class ReportMergeTests(unittest.TestCase):
         put_merge_url = get_server_location() + ASYNC_MERGE_URI
         with requests_mock.Mocker() as mocker:
             mocker.put(put_merge_url, status_code=400, json=put_report_data)
-            nac = ReportMergeCommand(SUBPARSER)
+
             args = Namespace(
                 scan_job_ids=None, json_files=None, report_ids=[1, 2], json_dir=None
             )
             with self.assertRaises(SystemExit):
                 with redirect_stdout(report_out):
-                    nac.main(args)
+                    self.command.main(args)
 
     def test_detail_merge_json_files(self):
         """Testing report merge command with json files."""
@@ -189,13 +194,13 @@ class ReportMergeTests(unittest.TestCase):
         captured_stdout = StringIO()
         with requests_mock.Mocker() as mocker, redirect_stdout(captured_stdout):
             mocker.post(put_merge_url, status_code=201, json=put_report_data)
-            nac = ReportMergeCommand(SUBPARSER)
+
             args = Namespace(
                 scan_job_ids=None,
                 json_files=[TMP_DETAILSFILE1[0], TMP_GOODDETAILS[0]],
                 report_ids=None,
             )
-            nac.main(args)
+            self.command.main(args)
             expected_msg = messages.REPORT_SUCCESSFULLY_MERGED % {
                 "id": "1",
                 "pkg_name": PKG_NAME,
@@ -205,7 +210,7 @@ class ReportMergeTests(unittest.TestCase):
     def test_detail_merge_json_files_not_exist(self):
         """Testing report merge file not found error with json files."""
         report_out = StringIO()
-        nac = ReportMergeCommand(SUBPARSER)
+
         args = Namespace(
             scan_job_ids=None,
             json_files=[TMP_DETAILSFILE1[0], NONEXIST_FILE[0]],
@@ -214,7 +219,7 @@ class ReportMergeTests(unittest.TestCase):
         )
         with self.assertRaises(SystemExit):
             with redirect_stdout(report_out):
-                nac.main(args)
+                self.command.main(args)
                 self.assertIn(
                     messages.FILE_NOT_FOUND % NONEXIST_FILE[0],
                     report_out.getvalue().strip(),
@@ -223,7 +228,7 @@ class ReportMergeTests(unittest.TestCase):
     def test_detail_merge_error_json_files(self):
         """Testing report merge error with json files."""
         report_out = StringIO()
-        nac = ReportMergeCommand(SUBPARSER)
+
         args = Namespace(
             scan_job_ids=None,
             json_files=[TMP_DETAILSFILE1[0], TMP_NOTJSONFILE[0]],
@@ -232,12 +237,12 @@ class ReportMergeTests(unittest.TestCase):
         )
         with self.assertRaises(SystemExit):
             with redirect_stdout(report_out):
-                nac.main(args)
+                self.command.main(args)
 
     def test_detail_merge_error_all_json_files(self):
         """Testing report merge error with all bad json files."""
         report_out = StringIO()
-        nac = ReportMergeCommand(SUBPARSER)
+
         args = Namespace(
             scan_job_ids=None,
             json_files=[TMP_BADDETAILS1[0], TMP_BADDETAILS2[0]],
@@ -246,12 +251,12 @@ class ReportMergeTests(unittest.TestCase):
         )
         with self.assertRaises(SystemExit):
             with redirect_stdout(report_out):
-                nac.main(args)
+                self.command.main(args)
 
     def test_detail_merge_only_one_json_file(self):
         """Testing report merge error with only 1 json file."""
         report_out = StringIO()
-        nac = ReportMergeCommand(SUBPARSER)
+
         args = Namespace(
             scan_job_ids=None,
             json_files=[
@@ -262,29 +267,29 @@ class ReportMergeTests(unittest.TestCase):
         )
         with self.assertRaises(SystemExit):
             with redirect_stdout(report_out):
-                nac.main(args)
+                self.command.main(args)
 
     def test_detail_merge_error_no_args(self):
         """Testing report merge error with no arguments."""
         report_out = StringIO()
-        nac = ReportMergeCommand(SUBPARSER)
+
         args = Namespace(
             scan_job_ids=None, json_files=None, report_ids=None, json_dir=None
         )
         with self.assertRaises(SystemExit):
             with redirect_stdout(report_out):
-                nac.main(args)
+                self.command.main(args)
 
     def test_detail_merge_error_too_few_args(self):
         """Testing report merge error with only 1 job id."""
         report_out = StringIO()
-        nac = ReportMergeCommand(SUBPARSER)
+
         args = Namespace(
             scan_job_ids=[1], json_files=None, report_ids=None, json_dir=None
         )
         with self.assertRaises(SystemExit):
             with redirect_stdout(report_out):
-                nac.main(args)
+                self.command.main(args)
 
     def test_detail_merge_json_directory(self):
         """Testing report merge command with json directory."""
@@ -293,11 +298,11 @@ class ReportMergeTests(unittest.TestCase):
         captured_stdout = StringIO()
         with requests_mock.Mocker() as mocker, redirect_stdout(captured_stdout):
             mocker.post(put_merge_url, status_code=201, json=put_report_data)
-            nac = ReportMergeCommand(SUBPARSER)
+
             args = Namespace(
                 scan_job_ids=None, json_files=None, report_ids=None, json_dir=["/tmp/"]
             )
-            nac.main(args)
+            self.command.main(args)
             expected_msg = messages.REPORT_SUCCESSFULLY_MERGED % {
                 "id": "1",
                 "pkg_name": PKG_NAME,
@@ -308,7 +313,7 @@ class ReportMergeTests(unittest.TestCase):
         """Testing report merge command with json_dir parameter (notdir)."""
         bad_json_directory = "/tmp/does/not/exist/1316"
         report_out = StringIO()
-        nac = ReportMergeCommand(SUBPARSER)
+
         args = Namespace(
             scan_job_ids=None,
             json_files=None,
@@ -317,12 +322,12 @@ class ReportMergeTests(unittest.TestCase):
         )
         with self.assertRaises(SystemExit):
             with redirect_stdout(report_out):
-                nac.main(args)
+                self.command.main(args)
 
     def test_detail_merge_json_directory_error_path_passed(self):
         """Testing report merge command with json_dir parameter (file)."""
         report_out = StringIO()
-        nac = ReportMergeCommand(SUBPARSER)
+
         args = Namespace(
             scan_job_ids=None,
             json_files=None,
@@ -331,12 +336,12 @@ class ReportMergeTests(unittest.TestCase):
         )
         with self.assertRaises(SystemExit):
             with redirect_stdout(report_out):
-                nac.main(args)
+                self.command.main(args)
 
     def test_detail_merge_json_invalid_report_type_passed(self):
         """Testing report merge command bad report_type."""
         report_out = StringIO()
-        nac = ReportMergeCommand(SUBPARSER)
+
         args = Namespace(
             scan_job_ids=None,
             json_files=None,
@@ -345,7 +350,7 @@ class ReportMergeTests(unittest.TestCase):
         )
         with self.assertRaises(SystemExit):
             with redirect_stdout(report_out):
-                nac.main(args)
+                self.command.main(args)
 
     def test_detail_merge_json_directory_no_detail_reports(self):
         """Testing report merge command with json_dir (no details)."""
@@ -354,10 +359,10 @@ class ReportMergeTests(unittest.TestCase):
             if os.path.isfile(file[0]):
                 os.remove(file[0])
         report_out = StringIO()
-        nac = ReportMergeCommand(SUBPARSER)
+
         args = Namespace(
             scan_job_ids=None, json_files=None, report_ids=None, json_dir="/tmp/"
         )
         with self.assertRaises(SystemExit):
             with redirect_stdout(report_out):
-                nac.main(args)
+                self.command.main(args)

--- a/qpc/report/tests_report_merge_status.py
+++ b/qpc/report/tests_report_merge_status.py
@@ -14,12 +14,16 @@ from qpc.report.merge_status import ReportMergeStatusCommand
 from qpc.tests_utilities import DEFAULT_CONFIG, HushUpStderr, redirect_stdout
 from qpc.utils import get_server_location, write_server_config
 
-PARSER = ArgumentParser()
-SUBPARSER = PARSER.add_subparsers(dest="subcommand")
-
 
 class ReportMergeStatusTests(unittest.TestCase):
     """Class for testing the report merge status commands for qpc."""
+
+    @classmethod
+    def setUpClass(cls):
+        """Set up test case."""
+        argument_parser = ArgumentParser()
+        subparser = argument_parser.add_subparsers(dest="subcommand")
+        cls.command = ReportMergeStatusCommand(subparser)
 
     # pylint: disable=invalid-name
     def setUp(self):
@@ -57,9 +61,9 @@ class ReportMergeStatusTests(unittest.TestCase):
         captured_stdout = StringIO()
         with requests_mock.Mocker() as mocker, redirect_stdout(captured_stdout):
             mocker.get(self.url + "1/", status_code=200, json=good_json)
-            nac = ReportMergeStatusCommand(SUBPARSER)
+
             args = Namespace(job_id="1")
-            nac.main(args)
+            self.command.main(args)
             result1 = messages.MERGE_JOB_ID_STATUS % {
                 "job_id": "1",
                 "status": "completed",
@@ -77,11 +81,11 @@ class ReportMergeStatusTests(unittest.TestCase):
         report_out = StringIO()
         with requests_mock.Mocker() as mocker:
             mocker.get(self.url + "1/", status_code=404, json=None)
-            nac = ReportMergeStatusCommand(SUBPARSER)
+
             args = Namespace(job_id="1")
             with self.assertRaises(SystemExit):
                 with redirect_stdout(report_out):
-                    nac.main(args)
+                    self.command.main(args)
                     self.assertEqual(
                         report_out.getvalue(), messages.MERGE_JOB_ID_NOT_FOUND % "1"
                     )

--- a/qpc/report/tests_report_upload.py
+++ b/qpc/report/tests_report_upload.py
@@ -24,12 +24,17 @@ TMP_GOODDETAILS = (
 )
 NONEXIST_FILE = "/tmp/does/not/exist/bad.json"
 JSON_FILES_LIST = [TMP_BADDETAILS1, TMP_GOODDETAILS]
-PARSER = ArgumentParser()
-SUBPARSER = PARSER.add_subparsers(dest="subcommand")
 
 
 class ReportUploadTests(unittest.TestCase):
     """Class for testing the scan show commands for qpc."""
+
+    @classmethod
+    def setUpClass(cls):
+        """Set up test case."""
+        argument_parser = ArgumentParser()
+        subparser = argument_parser.add_subparsers(dest="subcommand")
+        cls.command = ReportUploadCommand(subparser)
 
     # pylint: disable=invalid-name
     def setUp(self):
@@ -59,10 +64,10 @@ class ReportUploadTests(unittest.TestCase):
         put_merge_url = get_server_location() + ASYNC_MERGE_URI
         with requests_mock.Mocker() as mocker:
             mocker.post(put_merge_url, status_code=201, json=put_report_data)
-            nac = ReportUploadCommand(SUBPARSER)
+
             args = Namespace(json_file=TMP_GOODDETAILS[0])
             with self.assertLogs(level="INFO") as log:
-                nac.main(args)
+                self.command.main(args)
                 expected_message = messages.REPORT_SUCCESSFULLY_UPLOADED % {
                     "id": "1",
                     "pkg_name": PKG_NAME,
@@ -76,11 +81,11 @@ class ReportUploadTests(unittest.TestCase):
         put_merge_url = get_server_location() + ASYNC_MERGE_URI
         with requests_mock.Mocker() as mocker:
             mocker.post(put_merge_url, status_code=201, json=put_report_data)
-            nac = ReportUploadCommand(SUBPARSER)
+
             args = Namespace(json_file=TMP_BADDETAILS1[0])
             with self.assertLogs(level="ERROR") as log:
                 with self.assertRaises(SystemExit):
-                    nac.main(args)
+                    self.command.main(args)
                 err_msg = messages.REPORT_UPLOAD_FILE_INVALID_JSON % (
                     TMP_BADDETAILS1[0]
                 )
@@ -94,11 +99,11 @@ class ReportUploadTests(unittest.TestCase):
         put_merge_url = get_server_location() + ASYNC_MERGE_URI
         with requests_mock.Mocker() as mocker:
             mocker.post(put_merge_url, status_code=400, json=put_report_data)
-            nac = ReportUploadCommand(SUBPARSER)
+
             args = Namespace(json_file=TMP_GOODDETAILS[0])
             with self.assertLogs(level="ERROR") as log:
                 with self.assertRaises(SystemExit):
-                    nac.main(args)
+                    self.command.main(args)
                 err_msg = messages.REPORT_FAILED_TO_UPLOADED % (
                     put_report_data.get("error")
                 )

--- a/qpc/scan/tests_scan_add.py
+++ b/qpc/scan/tests_scan_add.py
@@ -17,12 +17,16 @@ from qpc.source import SOURCE_URI
 from qpc.tests_utilities import DEFAULT_CONFIG, HushUpStderr, redirect_stdout
 from qpc.utils import get_server_location, write_server_config
 
-PARSER = ArgumentParser()
-SUBPARSER = PARSER.add_subparsers(dest="subcommand")
-
 
 class ScanAddCliTests(unittest.TestCase):
     """Class for testing the scan add commands for qpc."""
+
+    @classmethod
+    def setUpClass(cls):
+        """Set up test case."""
+        argument_parser = ArgumentParser()
+        subparser = argument_parser.add_subparsers(dest="subcommand")
+        cls.command = ScanAddCommand(subparser)
 
     def setUp(self):
         """Create test setup."""
@@ -49,12 +53,12 @@ class ScanAddCliTests(unittest.TestCase):
         url = get_server_location() + SOURCE_URI + "?name=source_none"
         with requests_mock.Mocker() as mocker:
             mocker.get(url, status_code=200, json={"count": 0})
-            ssc = ScanAddCommand(SUBPARSER)
+
             args = Namespace(sources=["source_none"])
             with self.assertRaises(SystemExit):
                 with redirect_stdout(scan_out):
-                    ssc.main(args)
-                    ssc.main(args)
+                    self.command.main(args)
+                    self.command.main(args)
                     self.assertTrue(
                         'Source "source_none" does not exist' in scan_out.getvalue()
                     )
@@ -65,11 +69,11 @@ class ScanAddCliTests(unittest.TestCase):
         url = get_server_location() + SOURCE_URI + "?name=source1"
         with requests_mock.Mocker() as mocker:
             mocker.get(url, exc=requests.exceptions.SSLError)
-            ssc = ScanAddCommand(SUBPARSER)
+
             args = Namespace(sources=["source1"])
             with self.assertRaises(SystemExit):
                 with redirect_stdout(scan_out):
-                    ssc.main(args)
+                    self.command.main(args)
                     self.assertEqual(scan_out.getvalue(), CONNECTION_ERROR_MSG)
 
     def test_add_scan_conn_err(self):
@@ -78,11 +82,11 @@ class ScanAddCliTests(unittest.TestCase):
         url = get_server_location() + SOURCE_URI + "?name=source1"
         with requests_mock.Mocker() as mocker:
             mocker.get(url, exc=requests.exceptions.ConnectTimeout)
-            ssc = ScanAddCommand(SUBPARSER)
+
             args = Namespace(sources=["source1"])
             with self.assertRaises(SystemExit):
                 with redirect_stdout(scan_out):
-                    ssc.main(args)
+                    self.command.main(args)
                     self.assertEqual(scan_out.getvalue(), CONNECTION_ERROR_MSG)
 
     def test_add_scan_bad_resp(self):
@@ -91,11 +95,11 @@ class ScanAddCliTests(unittest.TestCase):
         url_get_source = get_server_location() + SOURCE_URI + "?name=source1"
         with requests_mock.Mocker() as mocker:
             mocker.get(url_get_source, status_code=500, json=None)
-            ssc = ScanAddCommand(SUBPARSER)
+
             args = Namespace(sources=["source1"], max_concurrency=50)
             with self.assertRaises(SystemExit):
                 with redirect_stdout(scan_out):
-                    ssc.main(args)
+                    self.command.main(args)
                     self.assertEqual(
                         scan_out.getvalue(), messages.SERVER_INTERNAL_ERROR
                     )
@@ -120,7 +124,7 @@ class ScanAddCliTests(unittest.TestCase):
         with requests_mock.Mocker() as mocker:
             mocker.get(url_get_source, status_code=200, json=source_data)
             mocker.post(url_post, status_code=201, json={"name": "scan1"})
-            ssc = ScanAddCommand(SUBPARSER)
+
             args = Namespace(
                 name="scan1",
                 sources=["source1"],
@@ -134,7 +138,7 @@ class ScanAddCliTests(unittest.TestCase):
                 ext_product_search_dirs=None,
             )
             with self.assertLogs(level="INFO") as log:
-                ssc.main(args)
+                self.command.main(args)
                 expected_message = messages.SCAN_ADDED % "scan1"
                 self.assertIn(expected_message, log.output[-1])
 
@@ -155,7 +159,7 @@ class ScanAddCliTests(unittest.TestCase):
         with requests_mock.Mocker() as mocker:
             mocker.get(url_get_source, status_code=200, json=source_data)
             mocker.post(url_post, status_code=201, json={"name": "scan1"})
-            ssc = ScanAddCommand(SUBPARSER)
+
             args = Namespace(
                 name="scan1",
                 sources=["source1"],
@@ -169,7 +173,7 @@ class ScanAddCliTests(unittest.TestCase):
                 ext_product_search_dirs=None,
             )
             with self.assertLogs(level="INFO") as log:
-                ssc.main(args)
+                self.command.main(args)
                 expected_message = messages.SCAN_ADDED % "scan1"
                 self.assertIn(expected_message, log.output[-1])
 
@@ -195,7 +199,7 @@ class ScanAddCliTests(unittest.TestCase):
         with requests_mock.Mocker() as mocker:
             mocker.get(url_get_source, status_code=200, json=source_data)
             mocker.post(url_post, status_code=201, json={"name": "scan1"})
-            ssc = ScanAddCommand(SUBPARSER)
+
             args = Namespace(
                 name="scan1",
                 sources=["source1"],
@@ -205,7 +209,7 @@ class ScanAddCliTests(unittest.TestCase):
                 ext_product_search_dirs="/foo/bar/",
             )
             with self.assertLogs(level="INFO") as log:
-                ssc.main(args)
+                self.command.main(args)
                 expected_message = messages.SCAN_ADDED % "scan1"
                 self.assertIn(expected_message, log.output[-1])
 
@@ -230,7 +234,7 @@ class ScanAddCliTests(unittest.TestCase):
         with requests_mock.Mocker() as mocker:
             mocker.get(url_get_source, status_code=200, json=source_data)
             mocker.post(url_post, status_code=201, json={"name": "scan1"})
-            ssc = ScanAddCommand(SUBPARSER)
+
             args = Namespace(
                 name="scan1",
                 sources=["source1"],
@@ -240,7 +244,7 @@ class ScanAddCliTests(unittest.TestCase):
                 ext_product_search_dirs=None,
             )
             with self.assertLogs(level="INFO") as log:
-                ssc.main(args)
+                self.command.main(args)
                 expected_message = messages.SCAN_ADDED % "scan1"
                 self.assertIn(expected_message, log.output[-1])
 
@@ -254,7 +258,7 @@ class ScanAddCliTests(unittest.TestCase):
         with requests_mock.Mocker() as mocker:
             mocker.get(url_get_source, status_code=200, json=source_data)
             mocker.post(url_post, status_code=201, json={"name": "scan1"})
-            ssc = ScanAddCommand(SUBPARSER)
+
             args = Namespace(
                 name="scan1",
                 sources=["source1"],
@@ -264,6 +268,6 @@ class ScanAddCliTests(unittest.TestCase):
                 ext_product_search_dirs=None,
             )
             with self.assertLogs(level="INFO") as log:
-                ssc.main(args)
+                self.command.main(args)
                 expected_message = messages.SCAN_ADDED % "scan1"
                 self.assertIn(expected_message, log.output[-1])

--- a/qpc/scan/tests_scan_cancel.py
+++ b/qpc/scan/tests_scan_cancel.py
@@ -15,15 +15,24 @@ from qpc.scan.cancel import ScanCancelCommand
 from qpc.tests_utilities import DEFAULT_CONFIG, HushUpStderr, redirect_stdout
 from qpc.utils import get_server_location, write_server_config
 
-PARSER = ArgumentParser()
-SUBPARSER = PARSER.add_subparsers(dest="subcommand")
-
 
 class ScanCancelCliTests(unittest.TestCase):
     """Class for testing the scan cancel commands for qpc."""
 
-    def setUp(self):
+    def _init_command(self):
+        """Initialize command."""
+        argument_parser = ArgumentParser()
+        subparser = argument_parser.add_subparsers(dest="subcommand")
+        return ScanCancelCommand(subparser)
+
+    def setUp(self):  # pylint: disable=invalid-name
         """Create test setup."""
+        # different from most other test cases where command is initialized once per
+        # class, this one requires to be initialized for each test method because
+        # SourceEditCommand instance modifies req_path on the fly. This seems to be a
+        # code smell to me, but I'm choosing to ignore it for now
+        self.command = self._init_command()
+
         write_server_config(DEFAULT_CONFIG)
         # Temporarily disable stderr for these tests, CLI errors clutter up
         # nosetests command.
@@ -41,11 +50,11 @@ class ScanCancelCliTests(unittest.TestCase):
         url = get_server_location() + SCAN_JOB_URI + "1/cancel/"
         with requests_mock.Mocker() as mocker:
             mocker.put(url, exc=requests.exceptions.SSLError)
-            nsc = ScanCancelCommand(SUBPARSER)
+
             args = Namespace(id="1")
             with self.assertRaises(SystemExit):
                 with redirect_stdout(scan_out):
-                    nsc.main(args)
+                    self.command.main(args)
                     self.assertEqual(scan_out.getvalue(), CONNECTION_ERROR_MSG)
 
     def test_cancel_scan_conn_err(self):
@@ -54,11 +63,11 @@ class ScanCancelCliTests(unittest.TestCase):
         url = get_server_location() + SCAN_JOB_URI + "1/cancel/"
         with requests_mock.Mocker() as mocker:
             mocker.put(url, exc=requests.exceptions.ConnectTimeout)
-            nsc = ScanCancelCommand(SUBPARSER)
+
             args = Namespace(id="1")
             with self.assertRaises(SystemExit):
                 with redirect_stdout(scan_out):
-                    nsc.main(args)
+                    self.command.main(args)
                     self.assertEqual(scan_out.getvalue(), CONNECTION_ERROR_MSG)
 
     def test_cancel_scan_internal_err(self):
@@ -67,11 +76,11 @@ class ScanCancelCliTests(unittest.TestCase):
         url = get_server_location() + SCAN_JOB_URI + "1/cancel/"
         with requests_mock.Mocker() as mocker:
             mocker.put(url, status_code=500, json={"error": ["Server Error"]})
-            nsc = ScanCancelCommand(SUBPARSER)
+
             args = Namespace(id="1")
             with self.assertRaises(SystemExit):
                 with redirect_stdout(scan_out):
-                    nsc.main(args)
+                    self.command.main(args)
                     self.assertEqual(scan_out.getvalue(), "Server Error")
 
     def test_cancel_scan_data(self):
@@ -79,9 +88,9 @@ class ScanCancelCliTests(unittest.TestCase):
         url = get_server_location() + SCAN_JOB_URI + "1/cancel/"
         with requests_mock.Mocker() as mocker:
             mocker.put(url, status_code=200, json=None)
-            nsc = ScanCancelCommand(SUBPARSER)
+
             args = Namespace(id="1")
             with self.assertLogs(level="INFO") as log:
-                nsc.main(args)
+                self.command.main(args)
                 expected_message = messages.SCAN_CANCELED % "1"
                 self.assertIn(expected_message, log.output[-1])

--- a/qpc/scan/tests_scan_restart.py
+++ b/qpc/scan/tests_scan_restart.py
@@ -15,15 +15,23 @@ from qpc.scan.restart import ScanRestartCommand
 from qpc.tests_utilities import DEFAULT_CONFIG, HushUpStderr, redirect_stdout
 from qpc.utils import get_server_location, write_server_config
 
-PARSER = ArgumentParser()
-SUBPARSER = PARSER.add_subparsers(dest="subcommand")
-
 
 class ScanRestartCliTests(unittest.TestCase):
     """Class for testing the scan restart commands for qpc."""
 
-    def setUp(self):
+    def _init_command(self):
+        """Initialize command."""
+        argument_parser = ArgumentParser()
+        subparser = argument_parser.add_subparsers(dest="subcommand")
+        return ScanRestartCommand(subparser)
+
+    def setUp(self):  # pylint: disable=invalid-name
         """Create test setup."""
+        # different from most other test cases where command is initialized once per
+        # class, this one requires to be initialized for each test method because
+        # SourceEditCommand instance modifies req_path on the fly. This seems to be a
+        # code smell to me, but I'm choosing to ignore it for now
+        self.command = self._init_command()
         write_server_config(DEFAULT_CONFIG)
         # Temporarily disable stderr for these tests, CLI errors clutter up
         # nosetests command.
@@ -41,11 +49,11 @@ class ScanRestartCliTests(unittest.TestCase):
         url = get_server_location() + SCAN_JOB_URI + "1/restart/"
         with requests_mock.Mocker() as mocker:
             mocker.put(url, exc=requests.exceptions.SSLError)
-            nsc = ScanRestartCommand(SUBPARSER)
+
             args = Namespace(id="1")
             with self.assertRaises(SystemExit):
                 with redirect_stdout(scan_out):
-                    nsc.main(args)
+                    self.command.main(args)
                     self.assertEqual(scan_out.getvalue(), CONNECTION_ERROR_MSG)
 
     def test_restart_scan_conn_err(self):
@@ -54,11 +62,11 @@ class ScanRestartCliTests(unittest.TestCase):
         url = get_server_location() + SCAN_JOB_URI + "1/restart/"
         with requests_mock.Mocker() as mocker:
             mocker.put(url, exc=requests.exceptions.ConnectTimeout)
-            nsc = ScanRestartCommand(SUBPARSER)
+
             args = Namespace(id="1")
             with self.assertRaises(SystemExit):
                 with redirect_stdout(scan_out):
-                    nsc.main(args)
+                    self.command.main(args)
                     self.assertEqual(scan_out.getvalue(), CONNECTION_ERROR_MSG)
 
     def test_restart_scan_internal_err(self):
@@ -67,11 +75,11 @@ class ScanRestartCliTests(unittest.TestCase):
         url = get_server_location() + SCAN_JOB_URI + "1/restart/"
         with requests_mock.Mocker() as mocker:
             mocker.put(url, status_code=500, json={"error": ["Server Error"]})
-            nsc = ScanRestartCommand(SUBPARSER)
+
             args = Namespace(id="1")
             with self.assertRaises(SystemExit):
                 with redirect_stdout(scan_out):
-                    nsc.main(args)
+                    self.command.main(args)
                     self.assertEqual(scan_out.getvalue(), "Server Error")
 
     def test_restart_scan_data(self):
@@ -79,9 +87,9 @@ class ScanRestartCliTests(unittest.TestCase):
         url = get_server_location() + SCAN_JOB_URI + "1/restart/"
         with requests_mock.Mocker() as mocker:
             mocker.put(url, status_code=200, json=None)
-            nsc = ScanRestartCommand(SUBPARSER)
+
             args = Namespace(id="1")
             with self.assertLogs(level="INFO") as log:
-                nsc.main(args)
+                self.command.main(args)
                 expected_message = messages.SCAN_RESTARTED % "1"
                 self.assertIn(expected_message, log.output[-1])

--- a/qpc/server/tests_login_host.py
+++ b/qpc/server/tests_login_host.py
@@ -15,12 +15,17 @@ from qpc.tests_utilities import DEFAULT_CONFIG, HushUpStderr, redirect_stdout
 from qpc.utils import get_server_location, write_server_config
 
 TMP_KEY = "/tmp/testkey"
-PARSER = ArgumentParser()
-SUBPARSER = PARSER.add_subparsers(dest="subcommand")
 
 
 class LoginCliTests(unittest.TestCase):
     """Class for testing the login server command for qpc."""
+
+    @classmethod
+    def setUpClass(cls):
+        """Set up test case."""
+        argument_parser = ArgumentParser()
+        subparser = argument_parser.add_subparsers(dest="subcommand")
+        cls.command = LoginHostCommand(subparser)
 
     def setUp(self):
         """Create test setup."""
@@ -43,28 +48,28 @@ class LoginCliTests(unittest.TestCase):
         server_out = StringIO()
         e_msg = "Unable to log in with provided credentials."
         error = {"detail": [e_msg]}
-        with requests_mock.Mocker() as mocker:
+        with requests_mock.Mocker() as mocker, patch.object(
+            self.command, "password", "password"
+        ):
             mocker.post(self.login_url, status_code=400, json=error)
-            lhc = LoginHostCommand(SUBPARSER)
-            lhc.password = "password"
             args = Namespace(username="admin")
             do_mock_raw_input.return_value = "abc"
             with self.assertRaises(SystemExit):
                 with redirect_stdout(server_out):
-                    lhc.main(args)
+                    self.command.main(args)
                     self.assertTrue(e_msg in server_out.getvalue())
 
     @patch("getpass._raw_input")
     def test_login_good(self, do_mock_raw_input):
         """Testing the login with good creds."""
-        with requests_mock.Mocker() as mocker:
+        with requests_mock.Mocker() as mocker, patch.object(
+            self.command, "password", "password"
+        ):
             mocker.post(self.login_url, status_code=200, json=self.success_json)
-            lhc = LoginHostCommand(SUBPARSER)
-            lhc.password = "password"
             args = Namespace(username="admin")
             do_mock_raw_input.return_value = "abc"
             with self.assertLogs(level="INFO") as log:
-                lhc.main(args)
+                self.command.main(args)
                 self.assertIn(messages.LOGIN_SUCCESS, log.output[-1])
 
     @patch("builtins.input")
@@ -75,18 +80,18 @@ class LoginCliTests(unittest.TestCase):
         user_mock.return_value = "admin"
         with requests_mock.Mocker() as mocker:
             mocker.post(self.login_url, status_code=200, json=self.success_json)
-            lhc = LoginHostCommand(SUBPARSER)
+
             args = Namespace()
             with self.assertLogs(level="INFO") as log:
-                lhc.main(args)
+                self.command.main(args)
                 self.assertIn(messages.LOGIN_SUCCESS, log.output[-1])
 
     def test_no_prompts_with_args(self):
         """Testing no prompts with args passed."""
         with requests_mock.Mocker() as mocker:
             mocker.post(self.login_url, status_code=200, json=self.success_json)
-            lhc = LoginHostCommand(SUBPARSER)
+
             args = Namespace(username="admin", password="pass")
             with self.assertLogs(level="INFO") as log:
-                lhc.main(args)
+                self.command.main(args)
                 self.assertIn(messages.LOGIN_SUCCESS, log.output[-1])

--- a/qpc/server/tests_logout_host.py
+++ b/qpc/server/tests_logout_host.py
@@ -12,12 +12,16 @@ from qpc.server import LOGOUT_URI
 from qpc.server.logout_host import LogoutHostCommand
 from qpc.tests_utilities import HushUpStderr
 
-PARSER = ArgumentParser()
-SUBPARSER = PARSER.add_subparsers(dest="subcommand")
-
 
 class LogoutTests(unittest.TestCase):
     """Class for testing the logout host function."""
+
+    @classmethod
+    def setUpClass(cls):
+        """Set up test case."""
+        argument_parser = ArgumentParser()
+        subparser = argument_parser.add_subparsers(dest="subcommand")
+        cls.command = LogoutHostCommand(subparser)
 
     def setUp(self):
         """Create test setup."""
@@ -37,7 +41,6 @@ class LogoutTests(unittest.TestCase):
         url = utils.get_server_location() + LOGOUT_URI
         with requests_mock.Mocker() as mocker:
             mocker.put(url, status_code=200)
-            lhc = LogoutHostCommand(SUBPARSER)
             args = Namespace()
-            lhc.main(args)
+            self.command.main(args)
             self.assertFalse(os.path.exists(utils.QPC_CLIENT_TOKEN))

--- a/qpc/source/edit.py
+++ b/qpc/source/edit.py
@@ -30,8 +30,7 @@ class SourceEditCommand(CliCommand):
     def __init__(self, subparsers):
         """Create command."""
         # pylint: disable=no-member
-        CliCommand.__init__(
-            self,
+        super().__init__(
             self.SUBCOMMAND,
             self.ACTION,
             subparsers.add_parser(self.ACTION),


### PR DESCRIPTION
on python 3.11 argparser can't have subcommands overriden, something that was happening on the refactored tests.