### PR TITLE
Add packaging dependency

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -564,14 +564,14 @@ files = [
 
 [[package]]
 name = "packaging"
-version = "23.0"
+version = "23.1"
 description = "Core utilities for Python packages"
-category = "dev"
+category = "main"
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "packaging-23.0-py3-none-any.whl", hash = "sha256:714ac14496c3e68c99c29b00845f7a2b85f3bb6f1078fd9f72fd20f0570002b2"},
-    {file = "packaging-23.0.tar.gz", hash = "sha256:b6ad297f8907de0fa2fe1ccbd26fdaf387f5f47c7275fedf8cce89f99446cf97"},
+    {file = "packaging-23.1-py3-none-any.whl", hash = "sha256:994793af429502c4ea2ebf6bf664629d07c1a9fe974af92966e4b8d2df7edc61"},
+    {file = "packaging-23.1.tar.gz", hash = "sha256:a392980d2b6cffa644431898be54b0045151319d1e7ec34f0cfed48767dd334f"},
 ]
 
 [[package]]
@@ -1206,4 +1206,4 @@ files = [
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.8"
-content-hash = "e24a535bc7e65a6933e55df635253cddb6255c20925ec8fea310c40559886700"
+content-hash = "441b37f9a44c495ba94acf8cd0995f3ba3a02951a464caeee76bc23b51e0baf6"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,7 @@ qpc = 'qpc.__main__:main'
 python = "^3.8"
 requests = ">=2.28.1"
 cryptography = ">=37.0.4"
+packaging = "^23.1"
 
 [tool.poetry.group.dev.dependencies]
 coverage = ">=6.4.2"


### PR DESCRIPTION
With distutils deprecation we need to use packaging, which is not part of standard lib.