### PR TITLE
chore: build manpage during container build process

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,7 +23,7 @@ RUN microdnf update -y \
     && pip install -U pip \
     && pip install poetry \
     && poetry config virtualenvs.in-project true \
-    && poetry install -n --only main
+    && poetry install -n --only main --no-root
 
 ENV VIRTUAL_ENV=/app/qpc/.venv
 ENV PATH="${VIRTUAL_ENV}/bin:$PATH"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,10 @@
+FROM fedora as manpage_builder
+RUN dnf install -y make pandoc
+WORKDIR /app
+COPY docs/source/man.rst docs/source/man.rst
+COPY Makefile Makefile
+RUN make manpage
+
 FROM redhat/ubi9-minimal
 
 WORKDIR /app/qpc
@@ -28,9 +35,12 @@ RUN microdnf update -y \
 ENV VIRTUAL_ENV=/app/qpc/.venv
 ENV PATH="${VIRTUAL_ENV}/bin:$PATH"
 
-# Copy QPC
+# copy manpage
+COPY --from=manpage_builder /app/docs/qpc.1 /usr/local/share/man/man1/qpc.1
+
+# copy the rest of the application
 COPY . .
-COPY docs/qpc.1 /usr/local/share/man/man1/qpc.1
+# install the aplication itself
+RUN poetry install -n --only main --sync
 
 ENTRYPOINT ["deploy/docker_run.sh"]
-

--- a/Makefile
+++ b/Makefile
@@ -63,5 +63,5 @@ manpage:
 	  --variable=footer:'version $(PKG_VERSION)' \
 	  --variable=header:'QPC Command Line Guide'
 
-build-container: manpage
+build-container:
 	podman build -t quipucords-cli .


### PR DESCRIPTION
The same method is viable for downstream builds.

- [downstream build](https://url.corp.redhat.com/6a96f4e)
- [code](https://url.corp.redhat.com/41e670d)
