### PR TITLE
chore: adding setuptools as a dependency

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -694,6 +694,22 @@ files = [
 ]
 
 [[package]]
+name = "setuptools"
+version = "67.8.0"
+description = "Easily download, build, install, upgrade, and uninstall Python packages"
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "setuptools-67.8.0-py3-none-any.whl", hash = "sha256:5df61bf30bb10c6f756eb19e7c9f3b473051f48db77fddbe06ff2ca307df9a6f"},
+    {file = "setuptools-67.8.0.tar.gz", hash = "sha256:62642358adc77ffa87233bc4d2354c4b2682d214048f500964dbe760ccedf102"},
+]
+
+[package.extras]
+docs = ["furo", "jaraco.packaging (>=9)", "jaraco.tidelift (>=1.4)", "pygments-github-lexers (==0.0.5)", "rst.linker (>=1.9)", "sphinx (>=3.5)", "sphinx-favicon", "sphinx-hoverxref (<2)", "sphinx-inline-tabs", "sphinx-lint", "sphinx-notfound-page (==0.8.3)", "sphinx-reredirects", "sphinxcontrib-towncrier"]
+testing = ["build[virtualenv]", "filelock (>=3.4.0)", "flake8-2020", "ini2toml[lite] (>=0.9)", "jaraco.envs (>=2.2)", "jaraco.path (>=3.2.0)", "pip (>=19.1)", "pip-run (>=8.8)", "pytest (>=6)", "pytest-black (>=0.3.7)", "pytest-checkdocs (>=2.4)", "pytest-cov", "pytest-enabler (>=1.3)", "pytest-mypy (>=0.9.1)", "pytest-perf", "pytest-ruff", "pytest-timeout", "pytest-xdist", "tomli-w (>=1.0.0)", "virtualenv (>=13.0.0)", "wheel"]
+testing-integration = ["build[virtualenv]", "filelock (>=3.4.0)", "jaraco.envs (>=2.2)", "jaraco.path (>=3.2.0)", "pytest", "pytest-enabler", "pytest-xdist", "tomli", "virtualenv (>=13.0.0)", "wheel"]
+
+[[package]]
 name = "shellingham"
 version = "1.5.1"
 description = "Tool to Detect Surrounding Shell"
@@ -790,4 +806,4 @@ socks = ["PySocks (>=1.5.6,!=1.5.7,<2.0)"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.8"
-content-hash = "0748e56c1f7d013883d73a1c8394fc8006875864be23a11f74c24ea026fd921c"
+content-hash = "0d21a44280cfeb8831a3a8881ec76bfcdaf4cfb95ed5ed71fe77b4d273480839"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,6 +19,7 @@ requests = ">=2.28.1"
 cryptography = ">=37.0.4"
 packaging = "^23.1"
 ruff = "^0.0.270"
+setuptools = "^67.8.0"
 
 [tool.poetry.group.dev.dependencies]
 coverage = ">=6.4.2"


### PR DESCRIPTION
chore: adding setuptools as a dependency

- Adding setuptools as a poetry dependency.
   PyCharm would not open the qpc project off the bat without it.