### PR TITLE
feature: make qpc container compatible with toolbox

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,16 +17,21 @@ VOLUME ["/root/.local/share/qpc"]
 COPY pyproject.toml poetry.lock ./
 RUN microdnf update -y \
     && microdnf install -y \
+        coreutils-single \
         git \
         jq \
+        libcap \
         make \
-        man-db \
         man \
+        man-db \
         openssh-clients \
+        passwd \
         procps-ng \
         python3.11 \
         python3.11-pip \
+        shadow-utils \
         tar \
+        util-linux \
         which \
     && if [[ ! -e /usr/bin/python ]]; then ln -sf /usr/bin/python3.11 /usr/bin/python; fi \
     && if [[ ! -e /usr/bin/pip    ]]; then ln -sf /usr/bin/pip3.11    /usr/bin/pip;    fi \
@@ -46,4 +51,7 @@ COPY . .
 # install the aplication itself
 RUN poetry install -n --only main --sync
 
-ENTRYPOINT ["deploy/docker_run.sh"]
+LABEL com.github.containers.toolbox="true"
+# toolbox requires an "empty"entrypoint - which is fine, CMD is ok for qpc usecase
+CMD ["deploy/docker_run.sh"]
+ENTRYPOINT []

--- a/deploy/docker_run.sh
+++ b/deploy/docker_run.sh
@@ -6,11 +6,12 @@ if [ "${QPC_COMMAND}" = "man" ]; then
   shift
   man "${@}"
 elif [ -n "${QPC_COMMAND}" ]; then
-  poetry run $QPC_VAR_PROGRAM_NAME "${@}"
+  poetry run ${QPC_VAR_PROGRAM_NAME} "${@}"
 else
   echo "Usage:"
   echo "   $ alias ${QPC_VAR_PROGRAM_NAME}=\"docker run -it -v ~/.config/qpc:/root/.config/qpc \\"
   echo "                               -v ~/.local/share/qpc:/root/.local/share/qpc \\"
+  echo "                               --entrypoint='/app/qpc/deploy/docker_run.sh' \\"
   echo "                               ${QPC_VAR_PROGRAM_NAME}\""
   echo "   $ ${QPC_VAR_PROGRAM_NAME} [--help] <args>"
   echo "   $ ${QPC_VAR_PROGRAM_NAME} man <args>"

--- a/deploy/docker_run.sh
+++ b/deploy/docker_run.sh
@@ -9,8 +9,8 @@ elif [ -n "${QPC_COMMAND}" ]; then
   poetry run ${QPC_VAR_PROGRAM_NAME} "${@}"
 else
   echo "Usage:"
-  echo "   $ alias ${QPC_VAR_PROGRAM_NAME}=\"docker run -it -v ~/.config/qpc:/root/.config/qpc \\"
-  echo "                               -v ~/.local/share/qpc:/root/.local/share/qpc \\"
+  echo "   $ alias ${QPC_VAR_PROGRAM_NAME}=\"docker run -it -v ~/.config/qpc:/root/.config/qpc:z \\"
+  echo "                               -v ~/.local/share/qpc:/root/.local/share/qpc:z \\"
   echo "                               --entrypoint='/app/qpc/deploy/docker_run.sh' \\"
   echo "                               ${QPC_VAR_PROGRAM_NAME}\""
   echo "   $ ${QPC_VAR_PROGRAM_NAME} [--help] <args>"

--- a/deploy/qpc
+++ b/deploy/qpc
@@ -1,7 +1,21 @@
 #!/bin/bash
+
+if [[ -n $(command -v getenforce) ]]; then
+    # SELinux status can be enforced, permissive or disabled (ref: man getenforce)
+    SELINUX_STATUS=$(getenforce | tr '[:upper:]' '[:lower:]')
+else
+    SELINUX_STATUS=disabled
+fi
+
+if [[ "$SELINUX_STATUS" != "disabled" ]]; then
+    VOLUME_LABEL=":z"
+else
+    VOLUME_LABEL=""
+fi
+
 mkdir -p ~/.config/qpc ~/.local/share/qpc
 podman run -it --rm \
-    -v ~/.config/qpc:/root/.config/qpc \
-    -v ~/.local/share/qpc:/root/.local/share/qpc \
+    -v ~/.config/qpc:/root/.config/qpc${VOLUME_LABEL} \
+    -v ~/.local/share/qpc:/root/.local/share/qpc${VOLUME_LABEL} \
     --entrypoint='/app/qpc/deploy/docker_run.sh' \
     qpc "$@"

--- a/deploy/qpc
+++ b/deploy/qpc
@@ -1,5 +1,7 @@
 #!/bin/bash
 mkdir -p ~/.config/qpc ~/.local/share/qpc
-podman run -it  -v ~/.config/qpc:/root/.config/qpc \
-                -v ~/.local/share/qpc:/root/.local/share/qpc \
-                qpc "$@"
+podman run -it --rm \
+    -v ~/.config/qpc:/root/.config/qpc \
+    -v ~/.local/share/qpc:/root/.local/share/qpc \
+    --entrypoint='/app/qpc/deploy/docker_run.sh' \
+    qpc "$@"


### PR DESCRIPTION
Make qpc image compatible with toolbox.

## How to setup toolbox
```bash

make build-container
toolbox create --image qpc
```
## How to execute qpc through toolbox
Either run from host shell or from inside toolbox container
### From host shell
`toolbox run --container qpc <qpc /man qpc>`

### From toolbox container
 `toolbox enter qpc` and then run `qpc <command>` or `man qpc` .