### PR TITLE
feat: Support copying productized man pages

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -39,7 +39,7 @@ ENV VIRTUAL_ENV=/app/qpc/.venv
 ENV PATH="${VIRTUAL_ENV}/bin:$PATH"
 
 # copy manpage
-COPY --from=manpage_builder /app/docs/*.1 /usr/local/share/man/man1/qpc.1
+COPY --from=manpage_builder /app/docs/*.1 /usr/local/share/man/man1/
 
 # copy the rest of the application
 COPY . .


### PR DESCRIPTION
feat: Support copying productized man pages

- we need to support targets other than dsc.1, so copying all generated *.1 files to the man1/ directory.