### PR TITLE
feat: productize cli usage

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -75,4 +75,4 @@ manpage:
 	  --variable=header:'$(QPC_VAR_PROGRAM_NAME_UPPER) Command Line Guide'
 
 build-container:
-	podman build -t quipucords-cli .
+	podman build -t ${QPC_VAR_PROGRAM_NAME} .

--- a/deploy/docker_run.sh
+++ b/deploy/docker_run.sh
@@ -1,17 +1,18 @@
 #!/bin/bash
 cd /app/qpc
+QPC_VAR_PROGRAM_NAME="${QPC_VAR_PROGRAM_NAME:-qpc}"
 QPC_COMMAND="${1}"
 if [ "${QPC_COMMAND}" = "man" ]; then
   shift
   man "${@}"
 elif [ -n "${QPC_COMMAND}" ]; then
-  poetry run qpc "${@}"
+  poetry run $QPC_VAR_PROGRAM_NAME "${@}"
 else
   echo "Usage:"
-  echo "   $ alias qpc=\"docker run -it -v ~/.config/qpc:/root/.config/qpc \\"
+  echo "   $ alias ${QPC_VAR_PROGRAM_NAME}=\"docker run -it -v ~/.config/qpc:/root/.config/qpc \\"
   echo "                               -v ~/.local/share/qpc:/root/.local/share/qpc \\"
-  echo "                               quipucords-cli\""
-  echo "   $ qpc [--help] <args>"
-  echo "   $ qpc man <args>"
+  echo "                               ${QPC_VAR_PROGRAM_NAME}\""
+  echo "   $ ${QPC_VAR_PROGRAM_NAME} [--help] <args>"
+  echo "   $ ${QPC_VAR_PROGRAM_NAME} man <args>"
   exit 1
 fi

--- a/deploy/qpc
+++ b/deploy/qpc
@@ -2,4 +2,4 @@
 mkdir -p ~/.config/qpc ~/.local/share/qpc
 podman run -it  -v ~/.config/qpc:/root/.config/qpc \
                 -v ~/.local/share/qpc:/root/.local/share/qpc \
-                quipucords-cli "$@"
+                qpc "$@"


### PR DESCRIPTION
Use the same QPC_VAR_PROGRAM_NAME to "rebrand" qpc entrypoint. Also change image name for consistency.


Example usage
```
❯ podman run --rm -e QPC_VAR_PROGRAM_NAME=potato qpc
Usage:
   $ alias potato="docker run -it -v ~/.config/qpc:/root/.config/qpc \
                               -v ~/.local/share/qpc:/root/.local/share/qpc \
                               quipucords-cli"
   $ potato [--help] <args>
   $ potato man <args>
```