### PR TITLE
Skip upload container image step on PRs from forks... for real

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -38,7 +38,7 @@ jobs:
 
       - name: Push To quay.io
         # Forks don't have access to secrets and can't complete this step
-        if: ${{ github.repository_owner == 'quipucords' }}
+        if: ${{ github.repository == github.event.pull_request.head.repo.full_name }}
         uses: redhat-actions/push-to-registry@v2
         with:
           image: quipucords/qpc


### PR DESCRIPTION
See https://github.com/quipucords/quipucords/pull/2412

This time PR is created from same repo. This is by mistake, but gives us a chance to confirm that image **will** be uploaded.