### PR TITLE
chore(deps): move ruff to dev dependencies group

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -1079,4 +1079,4 @@ files = [
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.8"
-content-hash = "a75e54fc41738a2e598eaaf3259bb157909a587735c3f1492095a684eccbc90e"
+content-hash = "9b5fe26225e00ab39d5751c02404a08f0acd336322a6bd140c5544d40276f298"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,6 @@ python = "^3.8"
 requests = ">=2.28.1"
 cryptography = ">=37.0.4"
 packaging = "^23.1"
-ruff = "^0.0.270"
 setuptools = "^67.8.0"
 gitpython = "^3.1.32"
 
@@ -31,7 +30,7 @@ pytest-lazy-fixture = ">=0.6.3"
 requests-mock = ">=1.9.3"
 pytest-mock = "^3.8.2"
 rstcheck = "^6.1.1"
-
+ruff = "^0.0.270"
 
 [tool.poetry.group.build.dependencies]
 jinja-cli = "^1.2.2"


### PR DESCRIPTION
ruff should be labeled as a dev dependency (we don't need more rust dependencies than what we already have XD)