### PR TITLE
refactor: rename `--version-git` arg to `--build-sha` to better indicate its purpose

### DIFF
--- a/qpc/cli.py
+++ b/qpc/cli.py
@@ -63,7 +63,7 @@ from qpc.utils import (
 )
 
 
-class VersionGitAction(argparse.Action):
+class BuildShaAction(argparse.Action):
     """Action to show the current git commit SHA-1."""
 
     def __init__(
@@ -71,10 +71,10 @@ class VersionGitAction(argparse.Action):
         option_strings,
         dest=argparse.SUPPRESS,
         default=argparse.SUPPRESS,
-        help="show program's current git commit SHA-1 and exit",
+        help="show git commit SHA-1 used to build the program and exit",
     ):
-        """Initialize the VersionGitAction."""
-        super(VersionGitAction, self).__init__(
+        """Initialize the BuildShaAction."""
+        super(BuildShaAction, self).__init__(
             option_strings=option_strings,
             dest=dest,
             default=default,
@@ -106,7 +106,7 @@ class CLI:
         self.parser = argparse.ArgumentParser(usage=usage, description=description)
         self.parser.add_argument("--version", action="version", version=VERSION)
         self.parser.add_argument(
-            "--version-git", action=VersionGitAction, help=argparse.SUPPRESS
+            "--build-sha", action=BuildShaAction, help=argparse.SUPPRESS
         )
         self.parser.add_argument(
             "-v",

--- a/qpc/test_cli.py
+++ b/qpc/test_cli.py
@@ -18,9 +18,9 @@ def test_version(capsys):
     assert captured.out.strip() == VERSION
 
 
-def test_version_git(capsys):
-    """Test the `--version-git` argument."""
-    test_argv = ["/bin/qpc", "--version-git"]
+def test_build_sha(capsys):
+    """Test the `--build-sha` argument."""
+    test_argv = ["/bin/qpc", "--build-sha"]
     expected_value = "C00010FF"
     with pytest.raises(SystemExit), patch.object(sys, "argv", test_argv), patch.object(
         cli, "get_current_sha1"


### PR DESCRIPTION
Relates to JIRA: DISCOVERY-359 (https://issues.redhat.com/browse/DISCOVERY-359)

Followup to https://github.com/quipucords/qpc/pull/260 after a brief discussion in Slack.

Works same as before, just with a different argument:

```
❯ poetry run qpc --build-sha
2d510750503a33aa291429a4760382613d6a2515

❯ QPC_COMMIT=74205 poetry run qpc --build-sha
74205
```