### PR TITLE
push to registry regardless of fork, use more variables

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,6 +13,9 @@ env:
   # We had a problem with GitHub setting quay expiration label also during
   # merge to main, so we just set meaningless value as a workaround.
   EXPIRATION_LABEL: ${{ github.event_name == 'push' && 'quipucords.source=github' || 'quay.expires-after=3d' }}
+  IMAGE_NAME: ${{ vars.IMAGE_NAME || 'quipucords/qpc' }}
+  REGISTRY: ${{ vars.REGISTRY || 'quay.io' }}
+
 
 jobs:
   build:
@@ -28,7 +31,7 @@ jobs:
         id: build-image
         uses: redhat-actions/buildah-build@v2
         with:
-          image: quipucords/qpc
+          image: ${{ env.IMAGE_NAME }}
           tags: ${{ env.STABLE_TAG }} ${{ env.STABLE_TAG == 'main' && 'latest' || '' }}
           containerfiles: |
             ./Dockerfile
@@ -40,8 +43,8 @@ jobs:
         # Forks that do not set these secrets and may fail this step.
         uses: redhat-actions/push-to-registry@v2
         with:
-          image: quipucords/qpc
+          image: ${{ env.IMAGE_NAME }}
           tags: ${{ steps.build-image.outputs.tags }}
-          registry: quay.io/
+          registry: ${{ env.REGISTRY }}
           username: ${{ secrets.QUAYIO_USERNAME }}
           password: ${{ secrets.QUAYIO_PASSWORD }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,7 +12,7 @@ env:
   STABLE_TAG: ${{ github.event_name == 'push' && github.ref_name || format('pr-{0}', github.event.pull_request.number) }}
   # We had a problem with GitHub setting quay expiration label also during
   # merge to main, so we just set meaningless value as a workaround.
-  EXPIRATION_LABEL: ${{ github.event_name == 'push' && 'quipucords.source=github' || 'quay.expires-after=3d' }}
+  EXPIRATION_LABEL: ${{ github.event_name == 'push' && 'quipucords.source=github' || 'quay.expires-after=5d' }}
   IMAGE_NAME: ${{ vars.IMAGE_NAME || 'quipucords/qpc' }}
   REGISTRY: ${{ vars.REGISTRY || 'quay.io' }}
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -37,8 +37,7 @@ jobs:
             quipucords.cli.git_sha=${{ github.sha }}
 
       - name: Push To quay.io
-        # Forks don't have access to secrets and can't complete this step
-        if: ${{ github.repository == github.event.pull_request.head.repo.full_name }}
+        # Forks that do not set these secrets and may fail this step.
         uses: redhat-actions/push-to-registry@v2
         with:
           image: quipucords/qpc


### PR DESCRIPTION
This is implementing the same as https://github.com/quipucords/quipucords/pull/2419 but for this repo; see that PR for details.

Relates to JIRA: DISCOVERY-388
https://issues.redhat.com/browse/DISCOVERY-388
