### PR TITLE
replace jinja-cli with local python script

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -61,7 +61,7 @@ generate-man:
 	@export QPC_VAR_CURRENT_YEAR=$(shell date +'%Y') \
 	&& export QPC_VAR_PROJECT=$${QPC_VAR_PROJECT:-Quipucords} \
 	&& export QPC_VAR_PROGRAM_NAME=$${QPC_VAR_PROGRAM_NAME:-qpc} \
-	&& poetry run jinja -X QPC_VAR docs/source/man.j2 $(ARGS)
+	&& poetry run python docs/jinja-render.py -e '^QPC_VAR.*' -t docs/source/man.j2 $(ARGS)
 
 update-man.rst:
 	$(MAKE) generate-man ARGS="-o docs/source/man.rst"

--- a/docs/jinja-render.py
+++ b/docs/jinja-render.py
@@ -1,0 +1,78 @@
+"""
+Barebones command-line utility to render a Jinja template.
+
+Uses environment variables to populate the template.
+
+Example usage:
+
+    # define relevant environment variables
+    export QPC_VAR_PROGRAM_NAME=qpc
+    export QPC_VAR_PROJECT=Quipucords
+    export QPC_VAR_CURRENT_YEAR=$(date +'%Y')
+
+    # use stdin to read template and stdout to write output:
+    python ./jinja-render.py -e '^QPC_VAR_.*' \
+        < ./source/man.j2 > ./source/man.rst
+
+    # use arguments to specify template and output paths:
+    python ./jinja-render.py -e '^QPC_VAR_.*' \
+        -t ./source/man.j2 -o ./source/man.rst
+"""
+
+import argparse
+import os
+import re
+
+from jinja2 import DictLoader, Environment
+
+
+def get_env_vars(allow_pattern):
+    """Get the matching environment variables."""
+    env_vars = {}
+    re_pattern = re.compile(allow_pattern)
+    for key, value in os.environ.items():
+        if re_pattern.search(key):
+            env_vars[key] = value
+    return env_vars
+
+
+def get_template(template_file):
+    """Load the Jinja template."""
+    with template_file as f:
+        template_data = f.read()
+    return Environment(
+        loader=DictLoader({"-": template_data}), keep_trailing_newline=True
+    ).get_template("-")
+
+
+def get_args():
+    """Parse and return command line arguments."""
+    parser = argparse.ArgumentParser(description="Format Jinja template using env vars")
+    parser.add_argument(
+        "-e",
+        "--env_var_pattern",
+        type=str,
+        default="",
+        help="regex pattern to match environment variable names",
+    )
+    parser.add_argument("-o", "--output", type=argparse.FileType("w"), default="-")
+    parser.add_argument("-t", "--template", type=argparse.FileType("r"), default="-")
+    args = parser.parse_args()
+    return args
+
+
+def main():
+    """Parse command line args and render Jinja template to output."""
+    args = get_args()
+    template = get_template(template_file=args.template)
+    env_vars = get_env_vars(allow_pattern=args.env_var_pattern)
+    args.output.write(template.render(env_vars))
+    if hasattr(args.output, "name"):
+        # This is a side effect of how ArgumentParser handles files vs stdout.
+        # Real output files have a "name" attribute and should be closed.
+        # However, we do NOT want to close if it's stdout, which has no name.
+        args.output.close()
+
+
+if __name__ == "__main__":
+    main()

--- a/docs/test_jina_render.py
+++ b/docs/test_jina_render.py
@@ -1,0 +1,101 @@
+"""Tests for jinja-render.py standalone script."""
+
+import importlib.util
+import os
+import random
+import sys
+import tempfile
+from io import StringIO
+from pathlib import Path
+
+import pytest
+
+sample_jinja_template = "hello, {{ NAME }}"
+
+
+@pytest.fixture(scope="module")
+def jinja_render():
+    """
+    Import the jinja-render script as a module.
+
+    This is necessary because jinja-render.py is a standalone script
+    that does not live in a regular Python package.
+    """
+    module_name = "jinja_render"
+    file_path = Path(__file__).parent / "jinja-render.py"
+    spec = importlib.util.spec_from_file_location(module_name, file_path)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_get_env_vars(jinja_render, mocker):
+    """Test getting only env vars that match the given pattern."""
+    mocker.patch.dict(
+        os.environ,
+        {
+            "unrelated": "zero",
+            "QPC_THING": "one",
+            "QPC_thang": "two",
+            "NOT_QPC_OTHER": "three",
+        },
+        clear=True,
+    )
+    expected = {"QPC_THING": "one", "QPC_thang": "two"}
+    allow_pattern = "^QPC_.*"
+    actual = jinja_render.get_env_vars(allow_pattern)
+    assert actual == expected
+
+
+def test_read_stdin_write_stdout(jinja_render, mocker, capsys):
+    """Test reading the Jinja template from stdin and writing output to stdout."""
+    fake_name = str(random.random())
+    expected_stdout = f"hello, {fake_name}"
+
+    fake_env_vars = {"NAME": fake_name}
+    fake_sys_argv = ["script.py", "-e", ".*"]
+    fake_stdin = StringIO(sample_jinja_template)
+
+    mocker.patch.dict(os.environ, fake_env_vars, clear=True)
+    mocker.patch.object(sys, "argv", fake_sys_argv)
+    mocker.patch.object(sys, "stdin", fake_stdin)
+
+    jinja_render.main()
+    actual_stdout = capsys.readouterr().out
+    assert actual_stdout == expected_stdout
+
+
+@pytest.fixture
+def template_path():
+    """Temp file containing a Jija template."""
+    tmp_file = tempfile.NamedTemporaryFile()
+    tmp_file.write(sample_jinja_template.encode())
+    tmp_file.seek(0)
+    yield tmp_file.name
+    tmp_file.close()
+
+
+def test_read_file_write_file(jinja_render, template_path, mocker, capsys):
+    """Test reading the Jinja template from file and writing output to file."""
+    fake_name = str(random.random())
+    expected_stdout = f"hello, {fake_name}"
+    fake_env_vars = {"NAME": fake_name}
+    with tempfile.TemporaryDirectory() as output_directory:
+        output_path = Path(output_directory) / str(random.random())
+        fake_sys_argv = [
+            "script.py",
+            "-e",
+            ".*",
+            "-t",
+            template_path,
+            "-o",
+            str(output_path),
+        ]
+        mocker.patch.dict(os.environ, fake_env_vars, clear=True)
+        mocker.patch.object(sys, "argv", fake_sys_argv)
+        jinja_render.main()
+
+        with output_path.open() as output_file:
+            actual_output = output_file.read()
+
+    assert actual_output == expected_stdout

--- a/poetry.lock
+++ b/poetry.lock
@@ -12,17 +12,6 @@ files = [
 ]
 
 [[package]]
-name = "argparse-ext"
-version = "1.4.2"
-description = "argparse extension;"
-optional = false
-python-versions = "*"
-files = [
-    {file = "argparse-ext-1.4.2.tar.gz", hash = "sha256:266ef372853393a34a96405352c73c6598585026da6a26d01621fb07dc170df3"},
-    {file = "argparse_ext-1.4.2-py3-none-any.whl", hash = "sha256:a1b9e901f401c534d18d51f30a91b508fd89bc109e2b447ba21ce83e03b1122c"},
-]
-
-[[package]]
 name = "black"
 version = "23.9.1"
 description = "The uncompromising code formatter."
@@ -428,23 +417,6 @@ files = [
     {file = "iniconfig-2.0.0-py3-none-any.whl", hash = "sha256:b6a85871a79d2e3b22d2d1b94ac2824226a63c6b741c88f7ae975f18b6778374"},
     {file = "iniconfig-2.0.0.tar.gz", hash = "sha256:2d91e135bf72d31a410b17c16da610a82cb55f6b0477d1a902134b24a455b8b3"},
 ]
-
-[[package]]
-name = "jinja-cli"
-version = "1.2.2"
-description = "a command line interface to jinja;"
-optional = false
-python-versions = "*"
-files = [
-    {file = "jinja-cli-1.2.2.tar.gz", hash = "sha256:3a702c4a988046e02e08d7cf40a362bf2050aeafe08d926a54bc395610f0f5a2"},
-    {file = "jinja_cli-1.2.2-py3-none-any.whl", hash = "sha256:86afa68cb2c2626cb447a445b3ab41e5da59dbe3fafa609a4624fda9b250fde9"},
-]
-
-[package.dependencies]
-argparse-ext = "*"
-Jinja2 = ">=2.11.0"
-PyYAML = "*"
-xmltodict = "*"
 
 [[package]]
 name = "jinja2"
@@ -913,55 +885,6 @@ pytest = ">=5.0"
 dev = ["pre-commit", "pytest-asyncio", "tox"]
 
 [[package]]
-name = "pyyaml"
-version = "6.0.1"
-description = "YAML parser and emitter for Python"
-optional = false
-python-versions = ">=3.6"
-files = [
-    {file = "PyYAML-6.0.1-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:d858aa552c999bc8a8d57426ed01e40bef403cd8ccdd0fc5f6f04a00414cac2a"},
-    {file = "PyYAML-6.0.1-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:fd66fc5d0da6d9815ba2cebeb4205f95818ff4b79c3ebe268e75d961704af52f"},
-    {file = "PyYAML-6.0.1-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:69b023b2b4daa7548bcfbd4aa3da05b3a74b772db9e23b982788168117739938"},
-    {file = "PyYAML-6.0.1-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:81e0b275a9ecc9c0c0c07b4b90ba548307583c125f54d5b6946cfee6360c733d"},
-    {file = "PyYAML-6.0.1-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ba336e390cd8e4d1739f42dfe9bb83a3cc2e80f567d8805e11b46f4a943f5515"},
-    {file = "PyYAML-6.0.1-cp310-cp310-win32.whl", hash = "sha256:bd4af7373a854424dabd882decdc5579653d7868b8fb26dc7d0e99f823aa5924"},
-    {file = "PyYAML-6.0.1-cp310-cp310-win_amd64.whl", hash = "sha256:fd1592b3fdf65fff2ad0004b5e363300ef59ced41c2e6b3a99d4089fa8c5435d"},
-    {file = "PyYAML-6.0.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:6965a7bc3cf88e5a1c3bd2e0b5c22f8d677dc88a455344035f03399034eb3007"},
-    {file = "PyYAML-6.0.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:f003ed9ad21d6a4713f0a9b5a7a0a79e08dd0f221aff4525a2be4c346ee60aab"},
-    {file = "PyYAML-6.0.1-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:42f8152b8dbc4fe7d96729ec2b99c7097d656dc1213a3229ca5383f973a5ed6d"},
-    {file = "PyYAML-6.0.1-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:062582fca9fabdd2c8b54a3ef1c978d786e0f6b3a1510e0ac93ef59e0ddae2bc"},
-    {file = "PyYAML-6.0.1-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:d2b04aac4d386b172d5b9692e2d2da8de7bfb6c387fa4f801fbf6fb2e6ba4673"},
-    {file = "PyYAML-6.0.1-cp311-cp311-win32.whl", hash = "sha256:1635fd110e8d85d55237ab316b5b011de701ea0f29d07611174a1b42f1444741"},
-    {file = "PyYAML-6.0.1-cp311-cp311-win_amd64.whl", hash = "sha256:bf07ee2fef7014951eeb99f56f39c9bb4af143d8aa3c21b1677805985307da34"},
-    {file = "PyYAML-6.0.1-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:50550eb667afee136e9a77d6dc71ae76a44df8b3e51e41b77f6de2932bfe0f47"},
-    {file = "PyYAML-6.0.1-cp36-cp36m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:1fe35611261b29bd1de0070f0b2f47cb6ff71fa6595c077e42bd0c419fa27b98"},
-    {file = "PyYAML-6.0.1-cp36-cp36m-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:704219a11b772aea0d8ecd7058d0082713c3562b4e271b849ad7dc4a5c90c13c"},
-    {file = "PyYAML-6.0.1-cp36-cp36m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:afd7e57eddb1a54f0f1a974bc4391af8bcce0b444685d936840f125cf046d5bd"},
-    {file = "PyYAML-6.0.1-cp36-cp36m-win32.whl", hash = "sha256:fca0e3a251908a499833aa292323f32437106001d436eca0e6e7833256674585"},
-    {file = "PyYAML-6.0.1-cp36-cp36m-win_amd64.whl", hash = "sha256:f22ac1c3cac4dbc50079e965eba2c1058622631e526bd9afd45fedd49ba781fa"},
-    {file = "PyYAML-6.0.1-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:b1275ad35a5d18c62a7220633c913e1b42d44b46ee12554e5fd39c70a243d6a3"},
-    {file = "PyYAML-6.0.1-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:18aeb1bf9a78867dc38b259769503436b7c72f7a1f1f4c93ff9a17de54319b27"},
-    {file = "PyYAML-6.0.1-cp37-cp37m-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:596106435fa6ad000c2991a98fa58eeb8656ef2325d7e158344fb33864ed87e3"},
-    {file = "PyYAML-6.0.1-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:baa90d3f661d43131ca170712d903e6295d1f7a0f595074f151c0aed377c9b9c"},
-    {file = "PyYAML-6.0.1-cp37-cp37m-win32.whl", hash = "sha256:9046c58c4395dff28dd494285c82ba00b546adfc7ef001486fbf0324bc174fba"},
-    {file = "PyYAML-6.0.1-cp37-cp37m-win_amd64.whl", hash = "sha256:4fb147e7a67ef577a588a0e2c17b6db51dda102c71de36f8549b6816a96e1867"},
-    {file = "PyYAML-6.0.1-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:1d4c7e777c441b20e32f52bd377e0c409713e8bb1386e1099c2415f26e479595"},
-    {file = "PyYAML-6.0.1-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a0cd17c15d3bb3fa06978b4e8958dcdc6e0174ccea823003a106c7d4d7899ac5"},
-    {file = "PyYAML-6.0.1-cp38-cp38-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:28c119d996beec18c05208a8bd78cbe4007878c6dd15091efb73a30e90539696"},
-    {file = "PyYAML-6.0.1-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7e07cbde391ba96ab58e532ff4803f79c4129397514e1413a7dc761ccd755735"},
-    {file = "PyYAML-6.0.1-cp38-cp38-win32.whl", hash = "sha256:184c5108a2aca3c5b3d3bf9395d50893a7ab82a38004c8f61c258d4428e80206"},
-    {file = "PyYAML-6.0.1-cp38-cp38-win_amd64.whl", hash = "sha256:1e2722cc9fbb45d9b87631ac70924c11d3a401b2d7f410cc0e3bbf249f2dca62"},
-    {file = "PyYAML-6.0.1-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:9eb6caa9a297fc2c2fb8862bc5370d0303ddba53ba97e71f08023b6cd73d16a8"},
-    {file = "PyYAML-6.0.1-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:c8098ddcc2a85b61647b2590f825f3db38891662cfc2fc776415143f599bb859"},
-    {file = "PyYAML-6.0.1-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:5773183b6446b2c99bb77e77595dd486303b4faab2b086e7b17bc6bef28865f6"},
-    {file = "PyYAML-6.0.1-cp39-cp39-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:b786eecbdf8499b9ca1d697215862083bd6d2a99965554781d0d8d1ad31e13a0"},
-    {file = "PyYAML-6.0.1-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:bc1bf2925a1ecd43da378f4db9e4f799775d6367bdb94671027b73b393a7c42c"},
-    {file = "PyYAML-6.0.1-cp39-cp39-win32.whl", hash = "sha256:faca3bdcf85b2fc05d06ff3fbc1f83e1391b3e724afa3feba7d13eeab355484c"},
-    {file = "PyYAML-6.0.1-cp39-cp39-win_amd64.whl", hash = "sha256:510c9deebc5c0225e8c96813043e62b680ba2f9c50a08d3724c7f28a747d1486"},
-    {file = "PyYAML-6.0.1.tar.gz", hash = "sha256:bfdf460b1736c775f2ba9f6a92bca30bc2095067b8a9d77876d1fad6cc3b4a43"},
-]
-
-[[package]]
 name = "requests"
 version = "2.31.0"
 description = "Python HTTP for Humans."
@@ -1206,18 +1129,7 @@ files = [
     {file = "xdg-6.0.0.tar.gz", hash = "sha256:24278094f2d45e846d1eb28a2ebb92d7b67fc0cab5249ee3ce88c95f649a1c92"},
 ]
 
-[[package]]
-name = "xmltodict"
-version = "0.13.0"
-description = "Makes working with XML feel like you are working with JSON"
-optional = false
-python-versions = ">=3.4"
-files = [
-    {file = "xmltodict-0.13.0-py2.py3-none-any.whl", hash = "sha256:aa89e8fd76320154a40d19a0df04a4695fb9dc5ba977cbb68ab3e4eb225e7852"},
-    {file = "xmltodict-0.13.0.tar.gz", hash = "sha256:341595a488e3e01a85a9d8911d8912fd922ede5fecc4dce437eb4b6c8d037e56"},
-]
-
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.11"
-content-hash = "3ba4ef16cc2baced5f659a53cf7ca43847dd44c279f122c6e68002927e4af6b8"
+content-hash = "0a7b4ce747f580357f1b7a940e4ffbcd09767faa696dcc5b1774c0b0072f8a0f"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,8 +33,9 @@ ruff = "^0.0.292"
 pip-tools = "^7.1.0"
 pybuild-deps = "^0.1.1"
 
+
 [tool.poetry.group.build.dependencies]
-jinja-cli = "^1.2.2"
+jinja2 = "^3.1.2"
 
 [build-system]
 requires = ["poetry-core>=1.0.0"]

--- a/requirements-build.txt
+++ b/requirements-build.txt
@@ -38,7 +38,7 @@ setuptools-scm==8.0.4
     # via
     #   pluggy
     #   setuptools-rust
-trove-classifiers==2023.9.19
+trove-classifiers==2023.10.18
     # via hatchling
 typing-extensions==4.8.0
     # via


### PR DESCRIPTION
Packages for `jinja-cli` and `jinja-cli2` are not available in our downstream build system. Our use case for rendering Jinja template content is very simple, though. So, I wrote this small script to use the `jinja2` library directly (which we _do_ have available downstream for both RHEL8 and RHEL9) to replace our single use of the `jinja` program, and I dropped `jinja-cli` from our Poetry environment and replaced it with just `jinja2`.

I deliberately made this a standalone script and _not_ part of the `qpc` package because we want to run this as a build step downstream, and we don't need to install all of qpc just to generate the man page.