### PR TITLE
fix: warning: Selection of nursery rule `PLC1901` without the `--preview` flag is deprecated.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,6 +62,8 @@ ignore = [
 ]
 src = ["qpc"]
 target-version = "py311"
+preview = true
+explicit-preview-rules = true
 
 [tool.ruff.per-file-ignores]
 "**/commands.py" = ["F401"]


### PR DESCRIPTION
This should suppress the warnings that `ruff` has recently started outputting:

```
warning: Selection of nursery rule `PLC1901` without the `--preview` flag is deprecated.
warning: Selection of nursery rule `PLC1901` without the `--preview` flag is deprecated.
warning: Selection of nursery rule `PLC1901` without the `--preview` flag is deprecated.
```

Reference: https://docs.astral.sh/ruff/preview/#using-rules-that-are-in-preview