### PR TITLE
test: port CLI tests from Camayoc

### DIFF
--- a/qpc/tests/scan/test_scan_add.py
+++ b/qpc/tests/scan/test_scan_add.py
@@ -178,10 +178,10 @@ class TestScanAddCli:
         "disable_opt_products_value", ("1", "-100", "redhat_packages", "ifconfig")
     )
     def test_disable_optional_products_negative(
-        self, capsys, disable_opt_products_value
+        self, capsys, mocker, disable_opt_products_value
     ):
         """Test add scan with unknown disabled-optional-products value."""
-        sys.argv = [
+        fake_sys_argv = [
             "/bin/qpc",
             "scan",
             "add",
@@ -192,6 +192,7 @@ class TestScanAddCli:
             "--disabled-optional-products",
             disable_opt_products_value,
         ]
+        mocker.patch.object(sys, "argv", fake_sys_argv)
         with pytest.raises(SystemExit):
             CLI().main()
 
@@ -274,9 +275,11 @@ class TestScanAddCli:
     @pytest.mark.parametrize(
         "enabled_ext_products_value", ("1", "-100", "redhat_packages", "ifconfig")
     )
-    def test_enabled_ext_products_negative(self, capsys, enabled_ext_products_value):
+    def test_enabled_ext_products_negative(
+        self, capsys, mocker, enabled_ext_products_value
+    ):
         """Test add scan with unknown enabled-ext-product-search value."""
-        sys.argv = [
+        fake_sys_argv = [
             "/bin/qpc",
             "scan",
             "add",
@@ -287,6 +290,7 @@ class TestScanAddCli:
             "--enabled-ext-product-search",
             enabled_ext_products_value,
         ]
+        mocker.patch.object(sys, "argv", fake_sys_argv)
         with pytest.raises(SystemExit):
             CLI().main()
 

--- a/qpc/tests/scan/test_scan_add.py
+++ b/qpc/tests/scan/test_scan_add.py
@@ -174,6 +174,32 @@ class TestScanAddCli:
                 expected_message = messages.SCAN_ADDED % "scan1"
                 assert expected_message in caplog.text
 
+    @pytest.mark.parametrize(
+        "disable_opt_products_value", ("1", "-100", "redhat_packages", "ifconfig")
+    )
+    def test_disable_optional_products_negative(
+        self, capsys, disable_opt_products_value
+    ):
+        """Test add scan with unknown disabled-optional-products value."""
+        sys.argv = [
+            "/bin/qpc",
+            "scan",
+            "add",
+            "--name",
+            "scan_1",
+            "--sources",
+            "source_1",
+            "--disabled-optional-products",
+            disable_opt_products_value,
+        ]
+        with pytest.raises(SystemExit):
+            CLI().main()
+
+        expected_output = "--disabled-optional-products: invalid choice: '{}'"
+        out, err = capsys.readouterr()
+        assert out == ""
+        assert expected_output.format(disable_opt_products_value) in err
+
     def test_enabled_products_and_dirs(self, caplog):
         """Testing that the ext products & search dirs flags work correctly."""
         url_get_source = get_server_location() + SOURCE_URI + "?name=source1"
@@ -244,6 +270,30 @@ class TestScanAddCli:
                 self.command.main(args)
                 expected_message = messages.SCAN_ADDED % "scan1"
                 assert expected_message in caplog.text
+
+    @pytest.mark.parametrize(
+        "enabled_ext_products_value", ("1", "-100", "redhat_packages", "ifconfig")
+    )
+    def test_enabled_ext_products_negative(self, capsys, enabled_ext_products_value):
+        """Test add scan with unknown enabled-ext-product-search value."""
+        sys.argv = [
+            "/bin/qpc",
+            "scan",
+            "add",
+            "--name",
+            "scan_1",
+            "--sources",
+            "source_1",
+            "--enabled-ext-product-search",
+            enabled_ext_products_value,
+        ]
+        with pytest.raises(SystemExit):
+            CLI().main()
+
+        expected_output = "--enabled-ext-product-search: invalid choice: '{}'"
+        out, err = capsys.readouterr()
+        assert out == ""
+        assert expected_output.format(enabled_ext_products_value) in err
 
     def test_disable_optional_products_empty(self, caplog):
         """Testing that the disable-optional-products flag works correctly."""

--- a/qpc/tests/source/test_openshift_source_add.py
+++ b/qpc/tests/source/test_openshift_source_add.py
@@ -125,9 +125,9 @@ class TestOpenShiftAddSource:
         assert out == ""
         assert expected_output in err
 
-    def test_add_with_unknown_ssl_cert_verify_param(self, capsys, ocp_credential_mock):
+    def test_add_with_unknown_ssl_cert_verify_param(self, capsys, mocker):
         """Test ocp add source w/ unknown ssl-cert-verify param."""
-        sys.argv = [
+        fake_sys_argv = [
             "/bin/qpc",
             "source",
             "add",
@@ -144,6 +144,7 @@ class TestOpenShiftAddSource:
             "--disable-ssl",
             "false",
         ]
+        mocker.patch.object(sys, "argv", fake_sys_argv),
         with pytest.raises(SystemExit):
             CLI().main()
         expected_output = "--ssl-cert-verify: invalid choice: 'maybe'"
@@ -151,9 +152,9 @@ class TestOpenShiftAddSource:
         assert out == ""
         assert expected_output in err
 
-    def test_add_with_unknown_disable_ssl_param(self, capsys, ocp_credential_mock):
+    def test_add_with_unknown_disable_ssl_param(self, capsys, mocker):
         """Test ocp add source w/ unknown ssl-disable param."""
-        sys.argv = [
+        fake_sys_argv = [
             "/bin/qpc",
             "source",
             "add",
@@ -170,6 +171,7 @@ class TestOpenShiftAddSource:
             "--disable-ssl",
             "maybe",
         ]
+        mocker.patch.object(sys, "argv", fake_sys_argv),
         with pytest.raises(SystemExit):
             CLI().main()
         expected_output = "--disable-ssl: invalid choice: 'maybe'"

--- a/qpc/tests/source/test_openshift_source_add.py
+++ b/qpc/tests/source/test_openshift_source_add.py
@@ -125,6 +125,58 @@ class TestOpenShiftAddSource:
         assert out == ""
         assert expected_output in err
 
+    def test_add_with_unknown_ssl_cert_verify_param(self, capsys, ocp_credential_mock):
+        """Test ocp add source w/ unknown ssl-cert-verify param."""
+        sys.argv = [
+            "/bin/qpc",
+            "source",
+            "add",
+            "--name",
+            "ocp_source_1",
+            "--type",
+            OPENSHIFT_SOURCE_TYPE,
+            "--cred",
+            "ocp_cred_1",
+            "--hosts",
+            "[1.2.3.4]",
+            "--ssl-cert-verify",
+            "maybe",
+            "--disable-ssl",
+            "false",
+        ]
+        with pytest.raises(SystemExit):
+            CLI().main()
+        expected_output = "--ssl-cert-verify: invalid choice: 'maybe'"
+        out, err = capsys.readouterr()
+        assert out == ""
+        assert expected_output in err
+
+    def test_add_with_unknown_disable_ssl_param(self, capsys, ocp_credential_mock):
+        """Test ocp add source w/ unknown ssl-disable param."""
+        sys.argv = [
+            "/bin/qpc",
+            "source",
+            "add",
+            "--name",
+            "ocp_source_1",
+            "--type",
+            OPENSHIFT_SOURCE_TYPE,
+            "--cred",
+            "ocp_cred_1",
+            "--hosts",
+            "[1.2.3.4]",
+            "--ssl-cert-verify",
+            "false",
+            "--disable-ssl",
+            "maybe",
+        ]
+        with pytest.raises(SystemExit):
+            CLI().main()
+        expected_output = "--disable-ssl: invalid choice: 'maybe'"
+        out, err = capsys.readouterr()
+        assert out == ""
+        assert expected_output in err
+
     @pytest.mark.parametrize(
         "status_code, err_log_message",
         [

--- a/qpc/tests/source/test_source_add.py
+++ b/qpc/tests/source/test_source_add.py
@@ -98,10 +98,14 @@ class TestSourceAddCli:
     def test_validate_port_range_err(self):
         """Test the add source command with port validation out of range."""
         source_out = StringIO()
+        msg = (
+            "Port value {port} should be a positive integer"
+            " in the valid range (0-65535)"
+        )
         with pytest.raises(ArgumentTypeError):
             with redirect_stdout(source_out):
                 validate_port("65537")
-                assert "Port value 65537" in source_out.getvalue()
+                assert msg.format(port="65537") in source_out.getvalue()
 
     def test_validate_port_good(self):
         """Testing the add source command with port validation success."""


### PR DESCRIPTION
A little unexpectedly, there were few tests in Camayoc that checked CLI input validation. They bail out before any requests are sent, so can be safely tested at the unit level.