### PR TITLE
perf: optimize "source clear --all" and "scan clear --all" by using new bulk delete APIs

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -38,33 +38,33 @@ dev = ["freezegun (>=1.0,<2.0)", "pytest (>=6.0)", "pytest-cov"]
 
 [[package]]
 name = "black"
-version = "24.2.0"
+version = "24.3.0"
 description = "The uncompromising code formatter."
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "black-24.2.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:6981eae48b3b33399c8757036c7f5d48a535b962a7c2310d19361edeef64ce29"},
-    {file = "black-24.2.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:d533d5e3259720fdbc1b37444491b024003e012c5173f7d06825a77508085430"},
-    {file = "black-24.2.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:61a0391772490ddfb8a693c067df1ef5227257e72b0e4108482b8d41b5aee13f"},
-    {file = "black-24.2.0-cp310-cp310-win_amd64.whl", hash = "sha256:992e451b04667116680cb88f63449267c13e1ad134f30087dec8527242e9862a"},
-    {file = "black-24.2.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:163baf4ef40e6897a2a9b83890e59141cc8c2a98f2dda5080dc15c00ee1e62cd"},
-    {file = "black-24.2.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:e37c99f89929af50ffaf912454b3e3b47fd64109659026b678c091a4cd450fb2"},
-    {file = "black-24.2.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:4f9de21bafcba9683853f6c96c2d515e364aee631b178eaa5145fc1c61a3cc92"},
-    {file = "black-24.2.0-cp311-cp311-win_amd64.whl", hash = "sha256:9db528bccb9e8e20c08e716b3b09c6bdd64da0dd129b11e160bf082d4642ac23"},
-    {file = "black-24.2.0-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:d84f29eb3ee44859052073b7636533ec995bd0f64e2fb43aeceefc70090e752b"},
-    {file = "black-24.2.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:1e08fb9a15c914b81dd734ddd7fb10513016e5ce7e6704bdd5e1251ceee51ac9"},
-    {file = "black-24.2.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:810d445ae6069ce64030c78ff6127cd9cd178a9ac3361435708b907d8a04c693"},
-    {file = "black-24.2.0-cp312-cp312-win_amd64.whl", hash = "sha256:ba15742a13de85e9b8f3239c8f807723991fbfae24bad92d34a2b12e81904982"},
-    {file = "black-24.2.0-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:7e53a8c630f71db01b28cd9602a1ada68c937cbf2c333e6ed041390d6968faf4"},
-    {file = "black-24.2.0-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:93601c2deb321b4bad8f95df408e3fb3943d85012dddb6121336b8e24a0d1218"},
-    {file = "black-24.2.0-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:a0057f800de6acc4407fe75bb147b0c2b5cbb7c3ed110d3e5999cd01184d53b0"},
-    {file = "black-24.2.0-cp38-cp38-win_amd64.whl", hash = "sha256:faf2ee02e6612577ba0181f4347bcbcf591eb122f7841ae5ba233d12c39dcb4d"},
-    {file = "black-24.2.0-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:057c3dc602eaa6fdc451069bd027a1b2635028b575a6c3acfd63193ced20d9c8"},
-    {file = "black-24.2.0-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:08654d0797e65f2423f850fc8e16a0ce50925f9337fb4a4a176a7aa4026e63f8"},
-    {file = "black-24.2.0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ca610d29415ee1a30a3f30fab7a8f4144e9d34c89a235d81292a1edb2b55f540"},
-    {file = "black-24.2.0-cp39-cp39-win_amd64.whl", hash = "sha256:4dd76e9468d5536abd40ffbc7a247f83b2324f0c050556d9c371c2b9a9a95e31"},
-    {file = "black-24.2.0-py3-none-any.whl", hash = "sha256:e8a6ae970537e67830776488bca52000eaa37fa63b9988e8c487458d9cd5ace6"},
-    {file = "black-24.2.0.tar.gz", hash = "sha256:bce4f25c27c3435e4dace4815bcb2008b87e167e3bf4ee47ccdc5ce906eb4894"},
+    {file = "black-24.3.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:7d5e026f8da0322b5662fa7a8e752b3fa2dac1c1cbc213c3d7ff9bdd0ab12395"},
+    {file = "black-24.3.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:9f50ea1132e2189d8dff0115ab75b65590a3e97de1e143795adb4ce317934995"},
+    {file = "black-24.3.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:e2af80566f43c85f5797365077fb64a393861a3730bd110971ab7a0c94e873e7"},
+    {file = "black-24.3.0-cp310-cp310-win_amd64.whl", hash = "sha256:4be5bb28e090456adfc1255e03967fb67ca846a03be7aadf6249096100ee32d0"},
+    {file = "black-24.3.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:4f1373a7808a8f135b774039f61d59e4be7eb56b2513d3d2f02a8b9365b8a8a9"},
+    {file = "black-24.3.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:aadf7a02d947936ee418777e0247ea114f78aff0d0959461057cae8a04f20597"},
+    {file = "black-24.3.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:65c02e4ea2ae09d16314d30912a58ada9a5c4fdfedf9512d23326128ac08ac3d"},
+    {file = "black-24.3.0-cp311-cp311-win_amd64.whl", hash = "sha256:bf21b7b230718a5f08bd32d5e4f1db7fc8788345c8aea1d155fc17852b3410f5"},
+    {file = "black-24.3.0-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:2818cf72dfd5d289e48f37ccfa08b460bf469e67fb7c4abb07edc2e9f16fb63f"},
+    {file = "black-24.3.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:4acf672def7eb1725f41f38bf6bf425c8237248bb0804faa3965c036f7672d11"},
+    {file = "black-24.3.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c7ed6668cbbfcd231fa0dc1b137d3e40c04c7f786e626b405c62bcd5db5857e4"},
+    {file = "black-24.3.0-cp312-cp312-win_amd64.whl", hash = "sha256:56f52cfbd3dabe2798d76dbdd299faa046a901041faf2cf33288bc4e6dae57b5"},
+    {file = "black-24.3.0-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:79dcf34b33e38ed1b17434693763301d7ccbd1c5860674a8f871bd15139e7837"},
+    {file = "black-24.3.0-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:e19cb1c6365fd6dc38a6eae2dcb691d7d83935c10215aef8e6c38edee3f77abd"},
+    {file = "black-24.3.0-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:65b76c275e4c1c5ce6e9870911384bff5ca31ab63d19c76811cb1fb162678213"},
+    {file = "black-24.3.0-cp38-cp38-win_amd64.whl", hash = "sha256:b5991d523eee14756f3c8d5df5231550ae8993e2286b8014e2fdea7156ed0959"},
+    {file = "black-24.3.0-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:c45f8dff244b3c431b36e3224b6be4a127c6aca780853574c00faf99258041eb"},
+    {file = "black-24.3.0-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:6905238a754ceb7788a73f02b45637d820b2f5478b20fec82ea865e4f5d4d9f7"},
+    {file = "black-24.3.0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:d7de8d330763c66663661a1ffd432274a2f92f07feeddd89ffd085b5744f85e7"},
+    {file = "black-24.3.0-cp39-cp39-win_amd64.whl", hash = "sha256:7bb041dca0d784697af4646d3b62ba4a6b028276ae878e53f6b4f74ddd6db99f"},
+    {file = "black-24.3.0-py3-none-any.whl", hash = "sha256:41622020d7120e01d377f74249e677039d20e6344ff5851de8a10f11f513bf93"},
+    {file = "black-24.3.0.tar.gz", hash = "sha256:a0c9c4a0771afc6919578cec71ce82a3e31e054904e7197deacbc9382671c41f"},
 ]
 
 [package.dependencies]
@@ -303,63 +303,63 @@ files = [
 
 [[package]]
 name = "coverage"
-version = "7.4.3"
+version = "7.4.4"
 description = "Code coverage measurement for Python"
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "coverage-7.4.3-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:8580b827d4746d47294c0e0b92854c85a92c2227927433998f0d3320ae8a71b6"},
-    {file = "coverage-7.4.3-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:718187eeb9849fc6cc23e0d9b092bc2348821c5e1a901c9f8975df0bc785bfd4"},
-    {file = "coverage-7.4.3-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:767b35c3a246bcb55b8044fd3a43b8cd553dd1f9f2c1eeb87a302b1f8daa0524"},
-    {file = "coverage-7.4.3-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:ae7f19afe0cce50039e2c782bff379c7e347cba335429678450b8fe81c4ef96d"},
-    {file = "coverage-7.4.3-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ba3a8aaed13770e970b3df46980cb068d1c24af1a1968b7818b69af8c4347efb"},
-    {file = "coverage-7.4.3-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:ee866acc0861caebb4f2ab79f0b94dbfbdbfadc19f82e6e9c93930f74e11d7a0"},
-    {file = "coverage-7.4.3-cp310-cp310-musllinux_1_1_i686.whl", hash = "sha256:506edb1dd49e13a2d4cac6a5173317b82a23c9d6e8df63efb4f0380de0fbccbc"},
-    {file = "coverage-7.4.3-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:fd6545d97c98a192c5ac995d21c894b581f1fd14cf389be90724d21808b657e2"},
-    {file = "coverage-7.4.3-cp310-cp310-win32.whl", hash = "sha256:f6a09b360d67e589236a44f0c39218a8efba2593b6abdccc300a8862cffc2f94"},
-    {file = "coverage-7.4.3-cp310-cp310-win_amd64.whl", hash = "sha256:18d90523ce7553dd0b7e23cbb28865db23cddfd683a38fb224115f7826de78d0"},
-    {file = "coverage-7.4.3-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:cbbe5e739d45a52f3200a771c6d2c7acf89eb2524890a4a3aa1a7fa0695d2a47"},
-    {file = "coverage-7.4.3-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:489763b2d037b164846ebac0cbd368b8a4ca56385c4090807ff9fad817de4113"},
-    {file = "coverage-7.4.3-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:451f433ad901b3bb00184d83fd83d135fb682d780b38af7944c9faeecb1e0bfe"},
-    {file = "coverage-7.4.3-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:fcc66e222cf4c719fe7722a403888b1f5e1682d1679bd780e2b26c18bb648cdc"},
-    {file = "coverage-7.4.3-cp311-cp311-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:b3ec74cfef2d985e145baae90d9b1b32f85e1741b04cd967aaf9cfa84c1334f3"},
-    {file = "coverage-7.4.3-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:abbbd8093c5229c72d4c2926afaee0e6e3140de69d5dcd918b2921f2f0c8baba"},
-    {file = "coverage-7.4.3-cp311-cp311-musllinux_1_1_i686.whl", hash = "sha256:35eb581efdacf7b7422af677b92170da4ef34500467381e805944a3201df2079"},
-    {file = "coverage-7.4.3-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:8249b1c7334be8f8c3abcaaa996e1e4927b0e5a23b65f5bf6cfe3180d8ca7840"},
-    {file = "coverage-7.4.3-cp311-cp311-win32.whl", hash = "sha256:cf30900aa1ba595312ae41978b95e256e419d8a823af79ce670835409fc02ad3"},
-    {file = "coverage-7.4.3-cp311-cp311-win_amd64.whl", hash = "sha256:18c7320695c949de11a351742ee001849912fd57e62a706d83dfc1581897fa2e"},
-    {file = "coverage-7.4.3-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:b51bfc348925e92a9bd9b2e48dad13431b57011fd1038f08316e6bf1df107d10"},
-    {file = "coverage-7.4.3-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:d6cdecaedea1ea9e033d8adf6a0ab11107b49571bbb9737175444cea6eb72328"},
-    {file = "coverage-7.4.3-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:3b2eccb883368f9e972e216c7b4c7c06cabda925b5f06dde0650281cb7666a30"},
-    {file = "coverage-7.4.3-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:6c00cdc8fa4e50e1cc1f941a7f2e3e0f26cb2a1233c9696f26963ff58445bac7"},
-    {file = "coverage-7.4.3-cp312-cp312-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:b9a4a8dd3dcf4cbd3165737358e4d7dfbd9d59902ad11e3b15eebb6393b0446e"},
-    {file = "coverage-7.4.3-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:062b0a75d9261e2f9c6d071753f7eef0fc9caf3a2c82d36d76667ba7b6470003"},
-    {file = "coverage-7.4.3-cp312-cp312-musllinux_1_1_i686.whl", hash = "sha256:ebe7c9e67a2d15fa97b77ea6571ce5e1e1f6b0db71d1d5e96f8d2bf134303c1d"},
-    {file = "coverage-7.4.3-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:c0a120238dd71c68484f02562f6d446d736adcc6ca0993712289b102705a9a3a"},
-    {file = "coverage-7.4.3-cp312-cp312-win32.whl", hash = "sha256:37389611ba54fd6d278fde86eb2c013c8e50232e38f5c68235d09d0a3f8aa352"},
-    {file = "coverage-7.4.3-cp312-cp312-win_amd64.whl", hash = "sha256:d25b937a5d9ffa857d41be042b4238dd61db888533b53bc76dc082cb5a15e914"},
-    {file = "coverage-7.4.3-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:28ca2098939eabab044ad68850aac8f8db6bf0b29bc7f2887d05889b17346454"},
-    {file = "coverage-7.4.3-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:280459f0a03cecbe8800786cdc23067a8fc64c0bd51dc614008d9c36e1659d7e"},
-    {file = "coverage-7.4.3-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:6c0cdedd3500e0511eac1517bf560149764b7d8e65cb800d8bf1c63ebf39edd2"},
-    {file = "coverage-7.4.3-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:9a9babb9466fe1da12417a4aed923e90124a534736de6201794a3aea9d98484e"},
-    {file = "coverage-7.4.3-cp38-cp38-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:dec9de46a33cf2dd87a5254af095a409ea3bf952d85ad339751e7de6d962cde6"},
-    {file = "coverage-7.4.3-cp38-cp38-musllinux_1_1_aarch64.whl", hash = "sha256:16bae383a9cc5abab9bb05c10a3e5a52e0a788325dc9ba8499e821885928968c"},
-    {file = "coverage-7.4.3-cp38-cp38-musllinux_1_1_i686.whl", hash = "sha256:2c854ce44e1ee31bda4e318af1dbcfc929026d12c5ed030095ad98197eeeaed0"},
-    {file = "coverage-7.4.3-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:ce8c50520f57ec57aa21a63ea4f325c7b657386b3f02ccaedeccf9ebe27686e1"},
-    {file = "coverage-7.4.3-cp38-cp38-win32.whl", hash = "sha256:708a3369dcf055c00ddeeaa2b20f0dd1ce664eeabde6623e516c5228b753654f"},
-    {file = "coverage-7.4.3-cp38-cp38-win_amd64.whl", hash = "sha256:1bf25fbca0c8d121a3e92a2a0555c7e5bc981aee5c3fdaf4bb7809f410f696b9"},
-    {file = "coverage-7.4.3-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:3b253094dbe1b431d3a4ac2f053b6d7ede2664ac559705a704f621742e034f1f"},
-    {file = "coverage-7.4.3-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:77fbfc5720cceac9c200054b9fab50cb2a7d79660609200ab83f5db96162d20c"},
-    {file = "coverage-7.4.3-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:6679060424faa9c11808598504c3ab472de4531c571ab2befa32f4971835788e"},
-    {file = "coverage-7.4.3-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:4af154d617c875b52651dd8dd17a31270c495082f3d55f6128e7629658d63765"},
-    {file = "coverage-7.4.3-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:8640f1fde5e1b8e3439fe482cdc2b0bb6c329f4bb161927c28d2e8879c6029ee"},
-    {file = "coverage-7.4.3-cp39-cp39-musllinux_1_1_aarch64.whl", hash = "sha256:69b9f6f66c0af29642e73a520b6fed25ff9fd69a25975ebe6acb297234eda501"},
-    {file = "coverage-7.4.3-cp39-cp39-musllinux_1_1_i686.whl", hash = "sha256:0842571634f39016a6c03e9d4aba502be652a6e4455fadb73cd3a3a49173e38f"},
-    {file = "coverage-7.4.3-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:a78ed23b08e8ab524551f52953a8a05d61c3a760781762aac49f8de6eede8c45"},
-    {file = "coverage-7.4.3-cp39-cp39-win32.whl", hash = "sha256:c0524de3ff096e15fcbfe8f056fdb4ea0bf497d584454f344d59fce069d3e6e9"},
-    {file = "coverage-7.4.3-cp39-cp39-win_amd64.whl", hash = "sha256:0209a6369ccce576b43bb227dc8322d8ef9e323d089c6f3f26a597b09cb4d2aa"},
-    {file = "coverage-7.4.3-pp38.pp39.pp310-none-any.whl", hash = "sha256:7cbde573904625509a3f37b6fecea974e363460b556a627c60dc2f47e2fffa51"},
-    {file = "coverage-7.4.3.tar.gz", hash = "sha256:276f6077a5c61447a48d133ed13e759c09e62aff0dc84274a68dc18660104d52"},
+    {file = "coverage-7.4.4-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:e0be5efd5127542ef31f165de269f77560d6cdef525fffa446de6f7e9186cfb2"},
+    {file = "coverage-7.4.4-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:ccd341521be3d1b3daeb41960ae94a5e87abe2f46f17224ba5d6f2b8398016cf"},
+    {file = "coverage-7.4.4-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:09fa497a8ab37784fbb20ab699c246053ac294d13fc7eb40ec007a5043ec91f8"},
+    {file = "coverage-7.4.4-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:b1a93009cb80730c9bca5d6d4665494b725b6e8e157c1cb7f2db5b4b122ea562"},
+    {file = "coverage-7.4.4-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:690db6517f09336559dc0b5f55342df62370a48f5469fabf502db2c6d1cffcd2"},
+    {file = "coverage-7.4.4-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:09c3255458533cb76ef55da8cc49ffab9e33f083739c8bd4f58e79fecfe288f7"},
+    {file = "coverage-7.4.4-cp310-cp310-musllinux_1_1_i686.whl", hash = "sha256:8ce1415194b4a6bd0cdcc3a1dfbf58b63f910dcb7330fe15bdff542c56949f87"},
+    {file = "coverage-7.4.4-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:b91cbc4b195444e7e258ba27ac33769c41b94967919f10037e6355e998af255c"},
+    {file = "coverage-7.4.4-cp310-cp310-win32.whl", hash = "sha256:598825b51b81c808cb6f078dcb972f96af96b078faa47af7dfcdf282835baa8d"},
+    {file = "coverage-7.4.4-cp310-cp310-win_amd64.whl", hash = "sha256:09ef9199ed6653989ebbcaacc9b62b514bb63ea2f90256e71fea3ed74bd8ff6f"},
+    {file = "coverage-7.4.4-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:0f9f50e7ef2a71e2fae92774c99170eb8304e3fdf9c8c3c7ae9bab3e7229c5cf"},
+    {file = "coverage-7.4.4-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:623512f8ba53c422fcfb2ce68362c97945095b864cda94a92edbaf5994201083"},
+    {file = "coverage-7.4.4-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0513b9508b93da4e1716744ef6ebc507aff016ba115ffe8ecff744d1322a7b63"},
+    {file = "coverage-7.4.4-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:40209e141059b9370a2657c9b15607815359ab3ef9918f0196b6fccce8d3230f"},
+    {file = "coverage-7.4.4-cp311-cp311-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:8a2b2b78c78293782fd3767d53e6474582f62443d0504b1554370bde86cc8227"},
+    {file = "coverage-7.4.4-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:73bfb9c09951125d06ee473bed216e2c3742f530fc5acc1383883125de76d9cd"},
+    {file = "coverage-7.4.4-cp311-cp311-musllinux_1_1_i686.whl", hash = "sha256:1f384c3cc76aeedce208643697fb3e8437604b512255de6d18dae3f27655a384"},
+    {file = "coverage-7.4.4-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:54eb8d1bf7cacfbf2a3186019bcf01d11c666bd495ed18717162f7eb1e9dd00b"},
+    {file = "coverage-7.4.4-cp311-cp311-win32.whl", hash = "sha256:cac99918c7bba15302a2d81f0312c08054a3359eaa1929c7e4b26ebe41e9b286"},
+    {file = "coverage-7.4.4-cp311-cp311-win_amd64.whl", hash = "sha256:b14706df8b2de49869ae03a5ccbc211f4041750cd4a66f698df89d44f4bd30ec"},
+    {file = "coverage-7.4.4-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:201bef2eea65e0e9c56343115ba3814e896afe6d36ffd37bab783261db430f76"},
+    {file = "coverage-7.4.4-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:41c9c5f3de16b903b610d09650e5e27adbfa7f500302718c9ffd1c12cf9d6818"},
+    {file = "coverage-7.4.4-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d898fe162d26929b5960e4e138651f7427048e72c853607f2b200909794ed978"},
+    {file = "coverage-7.4.4-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:3ea79bb50e805cd6ac058dfa3b5c8f6c040cb87fe83de10845857f5535d1db70"},
+    {file = "coverage-7.4.4-cp312-cp312-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ce4b94265ca988c3f8e479e741693d143026632672e3ff924f25fab50518dd51"},
+    {file = "coverage-7.4.4-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:00838a35b882694afda09f85e469c96367daa3f3f2b097d846a7216993d37f4c"},
+    {file = "coverage-7.4.4-cp312-cp312-musllinux_1_1_i686.whl", hash = "sha256:fdfafb32984684eb03c2d83e1e51f64f0906b11e64482df3c5db936ce3839d48"},
+    {file = "coverage-7.4.4-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:69eb372f7e2ece89f14751fbcbe470295d73ed41ecd37ca36ed2eb47512a6ab9"},
+    {file = "coverage-7.4.4-cp312-cp312-win32.whl", hash = "sha256:137eb07173141545e07403cca94ab625cc1cc6bc4c1e97b6e3846270e7e1fea0"},
+    {file = "coverage-7.4.4-cp312-cp312-win_amd64.whl", hash = "sha256:d71eec7d83298f1af3326ce0ff1d0ea83c7cb98f72b577097f9083b20bdaf05e"},
+    {file = "coverage-7.4.4-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:d5ae728ff3b5401cc320d792866987e7e7e880e6ebd24433b70a33b643bb0384"},
+    {file = "coverage-7.4.4-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:cc4f1358cb0c78edef3ed237ef2c86056206bb8d9140e73b6b89fbcfcbdd40e1"},
+    {file = "coverage-7.4.4-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:8130a2aa2acb8788e0b56938786c33c7c98562697bf9f4c7d6e8e5e3a0501e4a"},
+    {file = "coverage-7.4.4-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:cf271892d13e43bc2b51e6908ec9a6a5094a4df1d8af0bfc360088ee6c684409"},
+    {file = "coverage-7.4.4-cp38-cp38-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:a4cdc86d54b5da0df6d3d3a2f0b710949286094c3a6700c21e9015932b81447e"},
+    {file = "coverage-7.4.4-cp38-cp38-musllinux_1_1_aarch64.whl", hash = "sha256:ae71e7ddb7a413dd60052e90528f2f65270aad4b509563af6d03d53e979feafd"},
+    {file = "coverage-7.4.4-cp38-cp38-musllinux_1_1_i686.whl", hash = "sha256:38dd60d7bf242c4ed5b38e094baf6401faa114fc09e9e6632374388a404f98e7"},
+    {file = "coverage-7.4.4-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:aa5b1c1bfc28384f1f53b69a023d789f72b2e0ab1b3787aae16992a7ca21056c"},
+    {file = "coverage-7.4.4-cp38-cp38-win32.whl", hash = "sha256:dfa8fe35a0bb90382837b238fff375de15f0dcdb9ae68ff85f7a63649c98527e"},
+    {file = "coverage-7.4.4-cp38-cp38-win_amd64.whl", hash = "sha256:b2991665420a803495e0b90a79233c1433d6ed77ef282e8e152a324bbbc5e0c8"},
+    {file = "coverage-7.4.4-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:3b799445b9f7ee8bf299cfaed6f5b226c0037b74886a4e11515e569b36fe310d"},
+    {file = "coverage-7.4.4-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:b4d33f418f46362995f1e9d4f3a35a1b6322cb959c31d88ae56b0298e1c22357"},
+    {file = "coverage-7.4.4-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:aadacf9a2f407a4688d700e4ebab33a7e2e408f2ca04dbf4aef17585389eff3e"},
+    {file = "coverage-7.4.4-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:7c95949560050d04d46b919301826525597f07b33beba6187d04fa64d47ac82e"},
+    {file = "coverage-7.4.4-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ff7687ca3d7028d8a5f0ebae95a6e4827c5616b31a4ee1192bdfde697db110d4"},
+    {file = "coverage-7.4.4-cp39-cp39-musllinux_1_1_aarch64.whl", hash = "sha256:5fc1de20b2d4a061b3df27ab9b7c7111e9a710f10dc2b84d33a4ab25065994ec"},
+    {file = "coverage-7.4.4-cp39-cp39-musllinux_1_1_i686.whl", hash = "sha256:c74880fc64d4958159fbd537a091d2a585448a8f8508bf248d72112723974cbd"},
+    {file = "coverage-7.4.4-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:742a76a12aa45b44d236815d282b03cfb1de3b4323f3e4ec933acfae08e54ade"},
+    {file = "coverage-7.4.4-cp39-cp39-win32.whl", hash = "sha256:d89d7b2974cae412400e88f35d86af72208e1ede1a541954af5d944a8ba46c57"},
+    {file = "coverage-7.4.4-cp39-cp39-win_amd64.whl", hash = "sha256:9ca28a302acb19b6af89e90f33ee3e1906961f94b54ea37de6737b7ca9d8827c"},
+    {file = "coverage-7.4.4-pp38.pp39.pp310-none-any.whl", hash = "sha256:b2c5edc4ac10a7ef6605a966c58929ec6c1bd0917fb8c15cb3363f65aa40e677"},
+    {file = "coverage-7.4.4.tar.gz", hash = "sha256:c901df83d097649e257e803be22592aedfd5182f07b3cc87d640bbb9afd50f49"},
 ]
 
 [package.extras]
@@ -725,13 +725,13 @@ files = [
 
 [[package]]
 name = "pydantic"
-version = "2.6.3"
+version = "2.6.4"
 description = "Data validation using Python type hints"
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "pydantic-2.6.3-py3-none-any.whl", hash = "sha256:72c6034df47f46ccdf81869fddb81aade68056003900a8724a4f160700016a2a"},
-    {file = "pydantic-2.6.3.tar.gz", hash = "sha256:e07805c4c7f5c6826e33a1d4c9d47950d7eaf34868e2690f8594d2e30241f11f"},
+    {file = "pydantic-2.6.4-py3-none-any.whl", hash = "sha256:cc46fce86607580867bdc3361ad462bab9c222ef042d3da86f2fb333e1d916c5"},
+    {file = "pydantic-2.6.4.tar.gz", hash = "sha256:b1704e0847db01817624a6b86766967f552dd9dbf3afba4004409f908dcc84e6"},
 ]
 
 [package.dependencies]
@@ -1304,13 +1304,13 @@ zstd = ["zstandard (>=0.18.0)"]
 
 [[package]]
 name = "wheel"
-version = "0.42.0"
+version = "0.43.0"
 description = "A built-package format for Python"
 optional = false
-python-versions = ">=3.7"
+python-versions = ">=3.8"
 files = [
-    {file = "wheel-0.42.0-py3-none-any.whl", hash = "sha256:177f9c9b0d45c47873b619f5b650346d632cdc35fb5e4d25058e09c9e581433d"},
-    {file = "wheel-0.42.0.tar.gz", hash = "sha256:c45be39f7882c9d34243236f2d63cbd58039e360f85d0913425fbd7ceea617a8"},
+    {file = "wheel-0.43.0-py3-none-any.whl", hash = "sha256:55c570405f142630c6b9f72fe09d9b67cf1477fcf543ae5b8dcb1f5b7377da81"},
+    {file = "wheel-0.43.0.tar.gz", hash = "sha256:465ef92c69fa5c5da2d1cf8ac40559a8c940886afcef87dcf14b9470862f1d85"},
 ]
 
 [package.extras]

--- a/qpc/messages.py
+++ b/qpc/messages.py
@@ -118,12 +118,15 @@ SOURCE_REMOVED = 'Source "%s" was removed.'
 SOURCE_FAILED_TO_REMOVE = 'Failed to remove source "%s".'
 SOURCE_NOT_FOUND = 'Source "%s" was not found.'
 SOURCE_NO_SOURCES_TO_REMOVE = "No sources exist to be removed."
-SOURCE_PARTIAL_REMOVE = (
-    "Some sources were removed. However, an error "
-    "occurred while removing the following sources: %s. For more "
-    "information, see the server log file."
+SOURCE_CLEAR_ALL_SKIPPED_ASSIGNED_TO_SCAN = (
+    "Could not delete source ID %(source_id)s "
+    "because it is assigned to at least one scan "
+    "(scan ID %(scan_ids)s)."
 )
-SOURCE_CLEAR_ALL_SUCCESS = "All sources were removed."
+SOURCE_CLEAR_ALL_SUMMARY = (
+    "Successfully deleted %(deleted_count)s sources. "
+    "%(skipped_count)s sources could not be deleted."
+)
 SOURCE_EDIT_NO_ARGS = "No arguments were provided to edit source %s."
 SOURCE_DOES_NOT_EXIST = 'Source "%s" does not exist.'
 

--- a/qpc/messages.py
+++ b/qpc/messages.py
@@ -174,12 +174,7 @@ SCAN_REMOVED = 'Scan "%s" was removed.'
 SCAN_FAILED_TO_REMOVE = 'Failed to remove scan "%s".'
 SCAN_NOT_FOUND = 'Scan "%s" was not found.'
 SCAN_NO_SCANS_TO_REMOVE = "No scans exist to be removed."
-SCAN_PARTIAL_REMOVE = (
-    "Some scans were removed. However, an error "
-    "occurred while removing the following scan: %s. For more "
-    "information, see the server log file."
-)
-SCAN_CLEAR_ALL_SUCCESS = "All scans were removed."
+SCAN_CLEAR_ALL_SUMMARY = "Successfully deleted %(deleted_count)s scans."
 SCAN_EDIT_NO_ARGS = "No arguments were provided to edit scan %s."
 SCAN_JOB_ID_STATUS = (
     'Provide the "--status" filter with a scan name to '

--- a/qpc/scan/__init__.py
+++ b/qpc/scan/__init__.py
@@ -23,6 +23,7 @@ SCAN_STATUS_FAILED = "failed"
 
 
 SCAN_URI = "/api/v1/scans/"
+SCAN_BULK_DELETE_URI = "/api/v1/scans/bulk_delete/"
 SCAN_JOB_URI = "/api/v1/jobs/"
 
 SCAN_TYPE_CONNECT = "connect"

--- a/qpc/source/__init__.py
+++ b/qpc/source/__init__.py
@@ -15,6 +15,7 @@ VCENTER_SOURCE_TYPE = "vcenter"
 RHACS_SOURCE_TYPE = "rhacs"
 
 SOURCE_URI = "/api/v1/sources/"
+SOURCE_BULK_DELETE_URI = "/api/v1/sources/bulk_delete/"
 SOURCE_TYPE_CHOICES = [
     ANSIBLE_SOURCE_TYPE,
     NETWORK_SOURCE_TYPE,

--- a/qpc/source/clear.py
+++ b/qpc/source/clear.py
@@ -7,7 +7,7 @@ from requests import codes
 
 from qpc import messages, source
 from qpc.clicommand import CliCommand
-from qpc.request import DELETE, GET, request
+from qpc.request import DELETE, GET, POST, request
 from qpc.translation import _
 from qpc.utils import handle_error_response
 
@@ -65,6 +65,39 @@ class SourceClearCommand(CliCommand):
                 logger.error(_(messages.SOURCE_FAILED_TO_REMOVE), name)
         return deleted
 
+    def _delete_all(self) -> bool:
+        """
+        Delete all sources.
+
+        :returns: True if all are deleted, or False if error or any are not deleted.
+        """
+        delete_uri = source.SOURCE_BULK_DELETE_URI
+        response = request(POST, delete_uri, payload={"ids": "all"}, parser=self.parser)
+        # Note: `request` handles most HTTP errors.
+        # So, we can trust response.status_code == codes.ok at this point.
+
+        response_json = response.json()
+        deleted = response_json.get("deleted", [])
+        skipped = response_json.get("skipped", [])
+        for skipped_info in skipped:
+            logger.error(
+                _(messages.SOURCE_CLEAR_ALL_SKIPPED_ASSIGNED_TO_SCAN),
+                {
+                    "source_id": skipped_info["source"],
+                    "scan_ids": ", ".join(
+                        (str(scan) for scan in skipped_info["scans"])
+                    ),
+                },
+            )
+        logger_summary, success = (
+            (logger.error, False) if len(skipped) else (logger.info, True)
+        )
+        logger_summary(
+            messages.SOURCE_CLEAR_ALL_SUMMARY,
+            {"deleted_count": len(deleted), "skipped_count": len(skipped)},
+        )
+        return success
+
     def _handle_response_success(self):
         json_data = self.response.json()
         count = json_data.get("count", 0)
@@ -80,18 +113,5 @@ class SourceClearCommand(CliCommand):
         elif count == 0:
             logger.error(_(messages.SOURCE_NO_SOURCES_TO_REMOVE))
             sys.exit(1)
-        else:
-            # remove all entries
-            remove_error = []
-            next_link = json_data.get("next")
-            for entry in results:
-                if self._delete_entry(entry, print_out=False) is False:
-                    remove_error.append(entry["name"])
-            if remove_error:
-                cred_err = ",".join(remove_error)
-                logger.error(_(messages.SOURCE_PARTIAL_REMOVE), cred_err)
-                sys.exit(1)
-            elif not next_link:
-                logger.info(messages.SOURCE_CLEAR_ALL_SUCCESS)
-            else:
-                self._do_command()
+        elif not self._delete_all():
+            sys.exit(1)

--- a/qpc/tests/cred/test_cred_clear.py
+++ b/qpc/tests/cred/test_cred_clear.py
@@ -1,4 +1,4 @@
-"""Test the CLI module."""
+"""Test the "cred clear" command"."""
 
 import logging
 import sys

--- a/qpc/tests/cred/test_cred_clear.py
+++ b/qpc/tests/cred/test_cred_clear.py
@@ -10,14 +10,23 @@ import requests
 import requests_mock
 
 from qpc import messages
-from qpc.cred import CREDENTIAL_URI
+from qpc.cred import CREDENTIAL_BULK_DELETE_URI, CREDENTIAL_URI
 from qpc.cred.clear import CredClearCommand
+from qpc.tests.mixins import BulkClearTestsMixin
 from qpc.tests.utilities import DEFAULT_CONFIG, HushUpStderr, redirect_stdout
 from qpc.utils import get_server_location, write_server_config
 
 
-class TestCredentialClearCli:
+class TestCredentialClearCli(BulkClearTestsMixin):
     """Class for testing the credential clear commands for qpc."""
+
+    _uri_object_root = CREDENTIAL_URI
+    _uri_bulk_delete = CREDENTIAL_BULK_DELETE_URI
+    _message_no_objects_to_remove = messages.CRED_NO_CREDS_TO_REMOVE
+    _message_clear_all_summary = messages.CRED_CLEAR_ALL_SUMMARY
+    _message_clear_all_skipped = messages.CRED_CLEAR_ALL_SKIPPED_ASSIGNED_TO_SOURCE
+    _bulk_delete_name = "credential"
+    _bulk_delete_skipped_because_name = "source"
 
     def setup_class(cls):
         """Set up test case."""
@@ -127,96 +136,3 @@ class TestCredentialClearCli:
             with pytest.raises(SystemExit):
                 with redirect_stdout(cred_out):
                     self.command.main(args)
-
-    def test_clear_all_empty(self):
-        """Testing the clear credential command successfully with stubbed data.
-
-        With empty list of credentials.
-        """
-        cred_out = StringIO()
-        get_url = get_server_location() + CREDENTIAL_URI
-        with requests_mock.Mocker() as mocker:
-            mocker.get(get_url, status_code=200, json={"count": 0})
-            args = Namespace(name=None)
-            with pytest.raises(SystemExit):
-                with redirect_stdout(cred_out):
-                    self.command.main(args)
-
-    def test_clear_all_but_some_are_skipped(self, faker, caplog):
-        """Test "clear all" when some credentials are not deleted."""
-        get_url = get_server_location() + CREDENTIAL_URI
-        delete_url = get_server_location() + CREDENTIAL_URI + "bulk_delete/"
-        all_credential_ids = [
-            faker.random_int() for _ in range(faker.random_int(min=5, max=15))
-        ]
-        get_response = {"count": len(all_credential_ids)}
-        skipped = [
-            {"credential": cred_id, "sources": [faker.random_int()]}
-            for cred_id in faker.random_sample(all_credential_ids)
-        ]
-        deleted = list(
-            set(all_credential_ids)
-            - set([skipped_cred["credential"] for skipped_cred in skipped])
-        )
-        bulk_delete_response = {"deleted": deleted, "skipped": skipped}
-        with requests_mock.Mocker() as mocker:
-            mocker.get(get_url, status_code=200, json=get_response)
-            mocker.post(delete_url, status_code=200, json=bulk_delete_response)
-            args = Namespace(name=None)
-            with pytest.raises(SystemExit), caplog.at_level(logging.ERROR):
-                self.command.main(args)
-            for skipped_cred in skipped:
-                assert messages.CRED_CLEAR_ALL_SKIPPED_ASSIGNED_TO_SOURCE % {
-                    "credential_id": skipped_cred["credential"],
-                    "source_ids": skipped_cred["sources"],
-                }
-            expected_message = messages.CRED_CLEAR_ALL_SUMMARY % {
-                "deleted_count": len(deleted),
-                "skipped_count": len(skipped),
-            }
-            assert expected_message in caplog.text
-
-    def test_clear_all_but_unexpected_error_in_initial_get(self, caplog, faker):
-        """Test "clear all" when the GET fails unexpectedly before the delete POST."""
-        get_url = get_server_location() + CREDENTIAL_URI
-        server_error_message = faker.sentence()
-        with requests_mock.Mocker() as mocker:
-            mocker.get(get_url, status_code=500, json=server_error_message)
-            args = Namespace(name=None)
-            with pytest.raises(SystemExit), caplog.at_level(logging.ERROR):
-                self.command.main(args)
-            assert server_error_message in caplog.text
-
-    def test_clear_all_but_unexpected_error_in_bulk_delete(self, caplog):
-        """Test "clear all" when an unexpected server error occurs during deletion."""
-        get_url = get_server_location() + CREDENTIAL_URI
-        delete_url = get_server_location() + CREDENTIAL_URI + "bulk_delete/"
-        get_response = {"count": 1}
-        with requests_mock.Mocker() as mocker:
-            mocker.get(get_url, status_code=200, json=get_response)
-            mocker.post(delete_url, status_code=500)
-            args = Namespace(name=None)
-            with pytest.raises(SystemExit), caplog.at_level(logging.ERROR):
-                self.command.main(args)
-            assert messages.SERVER_INTERNAL_ERROR in caplog.text
-
-    def test_clear_all(self, caplog, faker):
-        """Test "clear all" when all credentials are successfully deleted."""
-        get_url = get_server_location() + CREDENTIAL_URI
-        delete_url = get_server_location() + CREDENTIAL_URI + "bulk_delete/"
-        all_credential_ids = [
-            faker.random_int() for _ in range(faker.random_int(min=2, max=10))
-        ]
-        get_response = {"count": len(all_credential_ids)}
-        bulk_delete_response = {"deleted": all_credential_ids, "skipped": []}
-        with requests_mock.Mocker() as mocker:
-            mocker.get(get_url, status_code=200, json=get_response)
-            mocker.post(delete_url, status_code=200, json=bulk_delete_response)
-            args = Namespace(name=None)
-            with caplog.at_level(logging.INFO):
-                self.command.main(args)
-                expected_message = messages.CRED_CLEAR_ALL_SUMMARY % {
-                    "deleted_count": len(all_credential_ids),
-                    "skipped_count": 0,
-                }
-                assert expected_message in caplog.text

--- a/qpc/tests/mixins.py
+++ b/qpc/tests/mixins.py
@@ -1,0 +1,153 @@
+"""Mixin classes to reduce test code duplication."""
+
+import logging
+from abc import ABC, abstractmethod
+from argparse import Namespace
+
+import pytest
+import requests_mock
+
+from qpc.clicommand import CliCommand
+from qpc.utils import get_server_location
+
+
+class BulkClearTestsMixin(ABC):
+    """
+    Test the "clear" subcommand that uses bulk delete APIs.
+
+    Other test classes that use this mixin need to define the properties below
+    to customize the behaviors and expectations of these test methods.
+    """
+
+    command: CliCommand  # typically set in our test classes' setup_class
+
+    @property
+    @abstractmethod
+    def _uri_object_root(self) -> str:
+        """Root URI of the object (e.g. "/api/v1/scans/")."""
+
+    @property
+    @abstractmethod
+    def _uri_bulk_delete(self) -> str:
+        """Bulk delete URI (e.g. "/api/v1/scans/bulk_delete/")."""
+
+    @property
+    @abstractmethod
+    def _message_clear_all_summary(self) -> str:
+        """Message to display when "clear all" command completes."""
+
+    @property
+    @abstractmethod
+    def _message_clear_all_skipped(self) -> str | None:
+        """Message to display when "clear all" shows a skipped delete."""
+
+    @property
+    @abstractmethod
+    def _message_no_objects_to_remove(self) -> str:
+        """Message to display when no objects exist to remove."""
+
+    @property
+    @abstractmethod
+    def _bulk_delete_name(self) -> str:
+        """Name of object type as used in bulk delete API response."""
+
+    @property
+    @abstractmethod
+    def _bulk_delete_skipped_because_name(self) -> str | None:
+        """
+        Name of related type that could cause an object to be skipped.
+
+        If None, then tests assume that objects cannot be skipped in bulk delete.
+        """
+
+    def test_clear_all_empty(self, caplog):
+        """Testing the "clear" command successfully with an empty list of objects."""
+        get_url = get_server_location() + self._uri_object_root
+        expected_error = self._message_no_objects_to_remove
+        with requests_mock.Mocker() as mocker:
+            mocker.get(get_url, status_code=200, json={"count": 0})
+            args = Namespace(name=None)
+            with pytest.raises(SystemExit), caplog.at_level(logging.ERROR):
+                self.command.main(args)
+            assert expected_error in caplog.text
+
+    def test_clear_all_but_unexpected_error_in_initial_get(self, caplog, faker):
+        """Test "clear all" when the GET fails unexpectedly before the delete POST."""
+        get_url = get_server_location() + self._uri_object_root
+        server_error_message = faker.sentence()
+        with requests_mock.Mocker() as mocker:
+            mocker.get(get_url, status_code=500, json=server_error_message)
+            args = Namespace(name=None)
+            with pytest.raises(SystemExit), caplog.at_level(logging.ERROR):
+                self.command.main(args)
+            assert server_error_message in caplog.text
+
+    def test_clear_all(self, caplog, faker):
+        """Test "clear all" when all objects are successfully deleted."""
+        get_url = get_server_location() + self._uri_object_root
+        delete_url = get_server_location() + self._uri_bulk_delete
+
+        all_ids = [faker.random_int() for _ in range(faker.random_int(min=5, max=15))]
+        get_response = {"count": len(all_ids)}
+        bulk_delete_response = {"deleted": all_ids}
+        expected_response_message_parameters = {"deleted_count": len(all_ids)}
+
+        if self._bulk_delete_skipped_because_name:
+            expected_response_message_parameters["skipped_count"] = 0
+
+        expected_message = (
+            self._message_clear_all_summary % expected_response_message_parameters
+        )
+
+        with requests_mock.Mocker() as mocker:
+            mocker.get(get_url, status_code=200, json=get_response)
+            mocker.post(delete_url, status_code=200, json=bulk_delete_response)
+            args = Namespace(name=None)
+            with caplog.at_level(logging.INFO):
+                self.command.main(args)
+                assert expected_message in caplog.text
+
+    def test_clear_all_but_some_are_skipped(self, faker, caplog):
+        """Test "clear all" when some objects are not deleted."""
+        if not self._bulk_delete_skipped_because_name:
+            pytest.skip("skipping is not relevant for this api")
+
+        get_url = get_server_location() + self._uri_object_root
+        delete_url = get_server_location() + self._uri_bulk_delete
+        all_ids = [faker.random_int() for _ in range(faker.random_int(min=5, max=15))]
+        get_response = {"count": len(all_ids)}
+
+        skipped = [
+            {
+                self._bulk_delete_name: object_id,
+                f"{self._bulk_delete_skipped_because_name}s": [faker.random_int()],
+            }
+            for object_id in faker.random_sample(all_ids)
+        ]
+        deleted = list(
+            set(all_ids)
+            - set(
+                [skipped_object[self._bulk_delete_name] for skipped_object in skipped]
+            )
+        )
+        bulk_delete_response = {"deleted": deleted, "skipped": skipped}
+        with requests_mock.Mocker() as mocker:
+            mocker.get(get_url, status_code=200, json=get_response)
+            mocker.post(delete_url, status_code=200, json=bulk_delete_response)
+            args = Namespace(name=None)
+            with pytest.raises(SystemExit), caplog.at_level(logging.ERROR):
+                self.command.main(args)
+            for skipped_object in skipped:
+                assert self._message_clear_all_skipped % {
+                    f"{self._bulk_delete_name}_id": skipped_object[
+                        self._bulk_delete_name
+                    ],
+                    f"{self._bulk_delete_skipped_because_name}_ids": skipped_object[
+                        f"{self._bulk_delete_skipped_because_name}s"
+                    ],
+                }
+            expected_message = self._message_clear_all_summary % {
+                "deleted_count": len(deleted),
+                "skipped_count": len(skipped),
+            }
+            assert expected_message in caplog.text

--- a/qpc/tests/source/test_source_clear.py
+++ b/qpc/tests/source/test_source_clear.py
@@ -13,12 +13,21 @@ from qpc import messages
 from qpc.request import CONNECTION_ERROR_MSG
 from qpc.source import SOURCE_BULK_DELETE_URI, SOURCE_URI
 from qpc.source.clear import SourceClearCommand
+from qpc.tests.mixins import BulkClearTestsMixin
 from qpc.tests.utilities import DEFAULT_CONFIG, HushUpStderr, redirect_stdout
 from qpc.utils import get_server_location, write_server_config
 
 
-class TestSourceClearCli:
+class TestSourceClearCli(BulkClearTestsMixin):
     """Class for testing the source clear commands for qpc."""
+
+    _uri_object_root = SOURCE_URI
+    _uri_bulk_delete = SOURCE_BULK_DELETE_URI
+    _message_no_objects_to_remove = messages.SOURCE_NO_SOURCES_TO_REMOVE
+    _message_clear_all_summary = messages.SOURCE_CLEAR_ALL_SUMMARY
+    _message_clear_all_skipped = messages.SOURCE_CLEAR_ALL_SKIPPED_ASSIGNED_TO_SCAN
+    _bulk_delete_name = "source"
+    _bulk_delete_skipped_because_name = "scan"
 
     def setup_class(cls):
         """Set up test case."""
@@ -145,86 +154,3 @@ class TestSourceClearCli:
                     self.command.main(args)
                     expected = 'Failed to remove source "source1"'
                     assert expected in source_out.getvalue()
-
-    def test_clear_all_empty(self):
-        """Test the clear source command successfully.
-
-        With stubbed data empty list of sources
-        """
-        source_out = StringIO()
-        get_url = get_server_location() + SOURCE_URI
-        with requests_mock.Mocker() as mocker:
-            mocker.get(get_url, status_code=200, json={"count": 0})
-
-            args = Namespace(name=None)
-            with pytest.raises(SystemExit):
-                with redirect_stdout(source_out):
-                    self.command.main(args)
-                    expected = "No sources exist to be removed\n"
-                    assert source_out.getvalue() == expected
-
-    def test_clear_all_but_some_are_skipped(self, faker, caplog):
-        """Test "clear all" when some sources are not deleted."""
-        get_url = get_server_location() + SOURCE_URI
-        delete_url = get_server_location() + SOURCE_URI + "bulk_delete/"
-        all_source_ids = [
-            faker.random_int() for _ in range(faker.random_int(min=5, max=15))
-        ]
-        get_response = {"count": len(all_source_ids)}
-        skipped = [
-            {"source": source_id, "scans": [faker.random_int()]}
-            for source_id in faker.random_sample(all_source_ids)
-        ]
-        deleted = list(
-            set(all_source_ids)
-            - set([skipped_source["source"] for skipped_source in skipped])
-        )
-        bulk_delete_response = {"deleted": deleted, "skipped": skipped}
-        with requests_mock.Mocker() as mocker:
-            mocker.get(get_url, status_code=200, json=get_response)
-            mocker.post(delete_url, status_code=200, json=bulk_delete_response)
-            args = Namespace(name=None)
-            with pytest.raises(SystemExit), caplog.at_level(logging.ERROR):
-                self.command.main(args)
-            for skipped_source in skipped:
-                assert messages.SOURCE_CLEAR_ALL_SKIPPED_ASSIGNED_TO_SCAN % {
-                    "source_id": skipped_source["source"],
-                    "scan_ids": skipped_source["scans"],
-                }
-            expected_message = messages.SOURCE_CLEAR_ALL_SUMMARY % {
-                "deleted_count": len(deleted),
-                "skipped_count": len(skipped),
-            }
-            assert expected_message in caplog.text
-
-    def test_clear_all_but_unexpected_error_in_initial_get(self, caplog, faker):
-        """Test "clear all" when the GET fails unexpectedly before the delete POST."""
-        get_url = get_server_location() + SOURCE_URI
-        server_error_message = faker.sentence()
-        with requests_mock.Mocker() as mocker:
-            mocker.get(get_url, status_code=500, json=server_error_message)
-            args = Namespace(name=None)
-            with pytest.raises(SystemExit), caplog.at_level(logging.ERROR):
-                self.command.main(args)
-            assert server_error_message in caplog.text
-
-    def test_clear_all(self, caplog, faker):
-        """Test "clear all" when all sources are successfully deleted."""
-        get_url = get_server_location() + SOURCE_URI
-        delete_url = get_server_location() + SOURCE_BULK_DELETE_URI
-        all_source_ids = [
-            faker.random_int() for _ in range(faker.random_int(min=2, max=10))
-        ]
-        get_response = {"count": len(all_source_ids)}
-        bulk_delete_response = {"deleted": all_source_ids, "skipped": []}
-        with requests_mock.Mocker() as mocker:
-            mocker.get(get_url, status_code=200, json=get_response)
-            mocker.post(delete_url, status_code=200, json=bulk_delete_response)
-            args = Namespace(name=None)
-            with caplog.at_level(logging.INFO):
-                self.command.main(args)
-                expected_message = messages.SOURCE_CLEAR_ALL_SUMMARY % {
-                    "deleted_count": len(all_source_ids),
-                    "skipped_count": 0,
-                }
-                assert expected_message in caplog.text


### PR DESCRIPTION
…and also some refactoring cleanup along the way including:

* `docs: update test_cred_clear module docstring`
* `test: deduplicate similar clear all/bulk delete tests into a reusable mixin`
* `chore: make update-requirements`

This PR should also resolve https://github.com/quipucords/qpc/pull/318.