### PR TITLE
test: tests should not be excluded from coverage!

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,2 +1,2 @@
 [report]
-omit = */test*.py,*/manage.py,*/apps.py,*/wsgi.py,*/settings.py,*/migrations/*,*/docs/*,*.rst
+omit = */manage.py,*/apps.py,*/wsgi.py,*/settings.py,*/migrations/*,*/docs/*,*.rst

--- a/qpc/tests/cred/test_cred_add.py
+++ b/qpc/tests/cred/test_cred_add.py
@@ -1,4 +1,4 @@
-"""Test the CLI module."""
+"""Test the "cred add" command."""
 
 import logging
 import sys


### PR DESCRIPTION
I recently discovered that our coverage metrics were ignoring our tests, and that means we were missing the fact that some test code was never being executed. That's bad because test code not being executed means that our assertions are wrong or the underlying code it's testing is wrong. Either way, it's masking bugs.

Upon closer inspection, yes, missing test coverage indicates that we have bugs in our tests _and_ their underlying code. What a mess! 😮‍💨 This PR only fixes _some_ of the many problems in existing tests, but it does leave the code in a better state than I found it. There is still much to be done to make these tests useful and healthy.

Unfortunately, in this investigation, I found some tests that, once fixed to assert what they were _probably_ intended to assert, revealed that the underlying code that they were testing was actually not working as expected. Note the several new `pytest.mark.skip` and `FIXME` comments I added here. I do not have time now to refactor all of the problematic code I found. So, I'm leaving these breadcrumbs for future travelers to find and (hopefully) fix. 🤷‍♂️ 

This also means that the codecov changes are all over the place! Before my fixes, overall coverage fluctuates because tests were not previously included. After I fixed some badly written tests, their coverage increased, but after adding `skip` to tests that were covering buggy code, their coverage decreased. The net result is _this PR_ will very likely fail our codecov minimum coverage threshold. I think that's a side effect we just have to live with, as it acknowledges a reality that this project has been ignoring for far too long.