### PR TITLE
chore: bump version to 1.8.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ requires-python = ">=3.11, <3.12"
 
 [tool.poetry]
 name = "qpc"
-version = "1.7.0"
+version = "1.8.0"
 description = ""
 authors = ["QPC Team <quipucords@redhat.com>"]
 license = "GPLv3"

--- a/qpc.spec
+++ b/qpc.spec
@@ -3,7 +3,7 @@
 Name:           qpc
 Summary:        command-line client interface for quipucords
 
-Version:        1.7.0
+Version:        1.8.0
 Release:        1%{?dist}
 Epoch:          0
 
@@ -49,6 +49,12 @@ sed \
 %{python3_sitelib}/qpc-*.egg-info/
 
 %changelog
+* Mon May 13 2024 Bruno Ciconelle <bciconel@redhat.com> - 0:1.8.0-1
+- Drop support to Decision Manager (BRMS).
+- Refactor report upload to use the async view.
+- Optimize report merge.
+- Deprecate report merge-status; scan job should be used instead.
+
 * Fri Apr 26 2024 Brad Smith <brasmith@redhat.com> - 0:1.7.0-1
 - Improve user experience with paginated results.
 

--- a/qpc/utils.py
+++ b/qpc/utils.py
@@ -51,7 +51,7 @@ DEFAULT_INSIGHTS_CONFIG = {
 
 LOG_LEVEL_INFO = 0
 
-QPC_MIN_SERVER_VERSION = "1.6.0"
+QPC_MIN_SERVER_VERSION = "1.8.0"
 
 logging.captureWarnings(True)
 logger = logging.getLogger(__name__)


### PR DESCRIPTION
The latest refactor on merge and upload report apis require discovery 1.8.0 or greater.

Relates to JIRA: DISCOVERY-672