### PR TITLE
chore: Adding support for Fedora 39

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -20,9 +20,8 @@ jobs:
       - centos-stream-9-x86_64
       - centos-stream-9-aarch64
       # fedora is like an even farther future preview.
-      - fedora-38-x86_64
-      - fedora-38-aarch64
-      # - fedora-39  # currently not supported due to python 3.11 vs 3.12 issues
+      - fedora-39-x86_64
+      - fedora-39-aarch64
 
   - job: copr_build
     trigger: commit

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ To work with the qpc code, begin by cloning the repository:
 git clone git@github.com:quipucords/qpc.git
 ```
 
-qpc development requires Python 3.11 and Poetry. Install using your local pakage manager or manually from:
+qpc development requires Python 3.12 and Poetry. Install using your local pakage manager or manually from:
 
 * https://www.python.org/downloads/
 * https://python-poetry.org/

--- a/poetry.lock
+++ b/poetry.lock
@@ -1241,4 +1241,4 @@ files = [
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.11,<3.13"
-content-hash = "ba08581809c65e6635901f4bedee96026713e645b57d464e1541dbf4712d06f7"
+content-hash = "29bae542a4ed9398a7f50d4b6e3cc45ae8819dfd37bd50c55d270c0ce4f625fa"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,7 @@
 [project]
-requires-python = ">=3.11, <3.13"
+name = "qpc"
+version = "1.8.0"
+requires-python = ">=3.11,<3.13"
 
 [tool.poetry]
 name = "qpc"
@@ -20,7 +22,7 @@ qpc = 'qpc.__main__:main'
 python = ">=3.11,<3.13"
 requests = ">=2.28.1"
 cryptography = ">=37.0.4"
-setuptools = "^67.8.0"
+setuptools = ">=67.8.0"
 faker = "^20.0.3"
 
 [tool.poetry.group.dev.dependencies]

--- a/qpc.spec
+++ b/qpc.spec
@@ -1,5 +1,5 @@
-%global __python3 /usr/bin/python3.11
-%global python3_pkgversion 3.11
+%global __python3 /usr/bin/python3.12
+%global python3_pkgversion 3.12
 Name:           qpc
 Summary:        command-line client interface for quipucords
 


### PR DESCRIPTION
- Updated the packit config yaml to include Fedora 39 builds for both x86_64 and ARM architectures.
- Bumped poetry and pyproject to use 3.12