### PR TITLE
feat: better output and exit code from incomplete commands

### DIFF
--- a/qpc/cli.py
+++ b/qpc/cli.py
@@ -113,6 +113,9 @@ class CLI:
             default=0,
             help=_(messages.VERBOSITY_HELP),
         )
+        # Note: We deliberately omit "required=True" from this specific subparser.
+        # This means a bare "qpc" call with no arguments will still be handled by our
+        # code, not argparse's input validation, and result in us calling print_help.
         self.subparsers = self.parser.add_subparsers(dest="subcommand")
         self.name = name
         self.args = None
@@ -186,7 +189,9 @@ class CLI:
 
     def _add_subcommand(self, subcommand, actions):
         subcommand_parser = self.subparsers.add_parser(subcommand)
-        action_subparsers = subcommand_parser.add_subparsers(dest="action")
+        action_subparsers = subcommand_parser.add_subparsers(
+            dest="action", required=True
+        )
         self.subcommands[subcommand] = {}
         for action in actions:
             action_inst = action(action_subparsers)


### PR DESCRIPTION
This changes the way argparse validates incomplete subparser (subcommand) inputs. By setting `required=true`, argparse correctly halts processing, displays a useful error message, and returns a non-zero exit code.

Old handling of incomplete commands:

```
$ qpc server
usage: qpc [-h] [--version] [-v] {server,cred,source,scan,report,insights} ...

positional arguments:
  {server,cred,source,scan,report,insights}

options:
  -h, --help            show this help message and exit
  --version             show program's version number and exit
  -v                    Verbose mode. Use up to -vvvv for more verbosity.

$ echo $?
0
```

Note that the old output simply dumps the top-level help message which does not actually help with the provided `server` subcommand, and it exits with `0` which wrongly indicates success.

New handling of incomplete commands:

```
$ qpc server
usage: qpc server [-h] {config,login,logout,status} ...
qpc server: error: the following arguments are required: action

$ echo $?
2
```
