### PR TITLE
chore: bump min server version to 1.10.0

### DIFF
--- a/qpc/utils.py
+++ b/qpc/utils.py
@@ -51,7 +51,7 @@ DEFAULT_INSIGHTS_CONFIG = {
 
 LOG_LEVEL_INFO = 0
 
-QPC_MIN_SERVER_VERSION = "1.8.0"
+QPC_MIN_SERVER_VERSION = "1.10.0"
 
 logging.captureWarnings(True)
 logger = logging.getLogger(__name__)


### PR DESCRIPTION
This is not technically necessary, but the dev team wants to ensure that users are running on the latest versions of everything.

Relates to JIRA: DISCOVERY-795