### PR TITLE
fix: Don't warn about non-existing config file when creating it

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -54,18 +54,40 @@ def pytest_collection(session):
 @pytest.fixture
 def server_config():
     """
-    Create server config with require_token set to False.
+    Create server config.
 
-    Since all cli commands require qpc config and qpc login to be executed,
-    require_token must be False, to avoid passing login info
+    Tests that want to pass the initial login check, should also use client_token
+    fixture, or use only authenticated_client fixture (which pulls both server_config
+    and client_token).
     """
-    from qpc.utils import write_server_config
+    from qpc.utils import (
+        CONFIG_HOST_KEY,
+        CONFIG_PORT_KEY,
+        CONFIG_USE_HTTP,
+        write_server_config,
+    )
 
     return write_server_config(
         {
-            "host": "127.0.0.1",
-            "port": 8000,
-            "use_http": True,
-            "require_token": False,
+            CONFIG_HOST_KEY: "127.0.0.1",
+            CONFIG_PORT_KEY: 8000,
+            CONFIG_USE_HTTP: True,
         }
     )
+
+
+@pytest.fixture
+def client_token():
+    """Create fake client token."""
+    from qpc.utils import CLIENT_TOKEN_KEY, CLIENT_TOKEN_TEST_VALUE, write_client_token
+
+    write_client_token({CLIENT_TOKEN_KEY: CLIENT_TOKEN_TEST_VALUE})
+
+
+@pytest.fixture
+def authenticated_client(server_config, client_token):
+    """Create server config and client token, providing authenticated client setup.
+
+    Tests that wish to use unauthenticated client, should use server_config fixture.
+    """
+    pass

--- a/qpc/cli.py
+++ b/qpc/cli.py
@@ -56,7 +56,6 @@ from qpc.utils import (
     get_server_location,
     logger,
     read_client_token,
-    read_require_auth,
     setup_logging,
 )
 
@@ -208,22 +207,17 @@ class CLI:
         self.args = self.parser.parse_args()
         setup_logging(self.args.verbosity)
         is_server_cmd = self.args.subcommand == server.SUBCOMMAND
-        is_server_logout = is_server_cmd and self.args.action == server.LOGOUT
         is_server_config = is_server_cmd and self.args.action == server.CONFIG
 
         if not is_server_config:
             # Before attempting to run command, check server location
-            server_location = get_server_location()
-            if server_location is None or server_location == "":
+            if not get_server_location():
                 logger.error(_(messages.SERVER_CONFIG_REQUIRED), QPC_VAR_PROGRAM_NAME)
                 sys.exit(1)
 
-            if read_require_auth():
-                if (not is_server_cmd or is_server_logout) and not read_client_token():
-                    logger.error(
-                        _(messages.SERVER_LOGIN_REQUIRED), QPC_VAR_PROGRAM_NAME
-                    )
-                    sys.exit(1)
+            if not is_server_cmd and not read_client_token():
+                logger.error(_(messages.SERVER_LOGIN_REQUIRED), QPC_VAR_PROGRAM_NAME)
+                sys.exit(1)
 
         if self.args.subcommand in self.subcommands:
             subcommand = self.subcommands[self.args.subcommand]

--- a/qpc/cli.py
+++ b/qpc/cli.py
@@ -218,10 +218,12 @@ class CLI:
                 logger.error(_(messages.SERVER_CONFIG_REQUIRED), QPC_VAR_PROGRAM_NAME)
                 sys.exit(1)
 
-        if read_require_auth():
-            if (not is_server_cmd or is_server_logout) and not read_client_token():
-                logger.error(_(messages.SERVER_LOGIN_REQUIRED), QPC_VAR_PROGRAM_NAME)
-                sys.exit(1)
+            if read_require_auth():
+                if (not is_server_cmd or is_server_logout) and not read_client_token():
+                    logger.error(
+                        _(messages.SERVER_LOGIN_REQUIRED), QPC_VAR_PROGRAM_NAME
+                    )
+                    sys.exit(1)
 
         if self.args.subcommand in self.subcommands:
             subcommand = self.subcommands[self.args.subcommand]

--- a/qpc/insights/configure.py
+++ b/qpc/insights/configure.py
@@ -8,6 +8,10 @@ from qpc.insights.utils import validate_host
 from qpc.source.utils import validate_port
 from qpc.translation import _
 from qpc.utils import (
+    CONFIG_HOST_KEY,
+    CONFIG_PORT_KEY,
+    CONFIG_SSO_HOST_KEY,
+    CONFIG_USE_HTTP,
     DEFAULT_HOST_INSIGHTS_CONFIG,
     DEFAULT_PORT_INSIGHTS_CONFIG,
     DEFAULT_SSO_HOST_INSIGHTS_CONFIG,
@@ -71,10 +75,10 @@ class InsightsConfigureCommand(CliCommand):
     def _do_command(self):
         """Persist insights configuration."""
         insights_config = {
-            "host": self.args.host,
-            "port": int(self.args.port),
-            "use_http": self.args.use_http,
-            "sso_host": self.args.sso_host,
+            CONFIG_HOST_KEY: self.args.host,
+            CONFIG_PORT_KEY: int(self.args.port),
+            CONFIG_USE_HTTP: self.args.use_http,
+            CONFIG_SSO_HOST_KEY: self.args.sso_host,
         }
         write_insights_config(insights_config)
         logger.info(_(messages.INSIGHTS_CONFIG_SUCCESS), insights_config)

--- a/qpc/insights/publish.py
+++ b/qpc/insights/publish.py
@@ -16,7 +16,13 @@ from qpc.insights.http import InsightsClient
 from qpc.request import GET
 from qpc.request import request as qpc_request
 from qpc.translation import _
-from qpc.utils import read_insights_auth_token, read_insights_config
+from qpc.utils import (
+    CONFIG_HOST_KEY,
+    CONFIG_PORT_KEY,
+    CONFIG_USE_HTTP,
+    read_insights_auth_token,
+    read_insights_config,
+)
 
 logger = getLogger(__name__)
 
@@ -184,12 +190,12 @@ class InsightsPublishCommand(CliCommand):
     def _get_base_url(self):
         insights_config = read_insights_config()
 
-        if insights_config["use_http"]:
+        if insights_config[CONFIG_USE_HTTP]:
             protocol = "http://"
         else:
             protocol = "https://"
-        host = insights_config["host"]
-        port = insights_config["port"]
+        host = insights_config[CONFIG_HOST_KEY]
+        port = insights_config[CONFIG_PORT_KEY]
 
         base_url = f"{protocol}{host}:{port}"
         return base_url

--- a/qpc/server/configure_host.py
+++ b/qpc/server/configure_host.py
@@ -8,7 +8,13 @@ from qpc import messages
 from qpc.clicommand import CliCommand
 from qpc.source.utils import validate_port
 from qpc.translation import _
-from qpc.utils import write_server_config
+from qpc.utils import (
+    CONFIG_HOST_KEY,
+    CONFIG_PORT_KEY,
+    CONFIG_SSL_VERIFY,
+    CONFIG_USE_HTTP,
+    write_server_config,
+)
 
 logger = getLogger(__name__)
 
@@ -64,22 +70,14 @@ class ConfigureHostCommand(CliCommand):
             help=SUPPRESS,
             required=False,
         )
-        self.parser.add_argument(
-            "--disable-auth",
-            dest="require_token",
-            action="store_false",
-            help=SUPPRESS,
-            required=False,
-        )
 
     def _do_command(self):
         """Persist the server configuration."""
         server_config = {
-            "host": self.args.host,
-            "port": int(self.args.port),
-            "use_http": self.args.use_http,
-            "ssl_verify": self.args.ssl_verify,
-            "require_token": self.args.require_token,
+            CONFIG_HOST_KEY: self.args.host,
+            CONFIG_PORT_KEY: int(self.args.port),
+            CONFIG_USE_HTTP: self.args.use_http,
+            CONFIG_SSL_VERIFY: self.args.ssl_verify,
         }
         write_server_config(server_config)
         protocol = "https"

--- a/qpc/tests/cred/conftest.py
+++ b/qpc/tests/cred/conftest.py
@@ -4,7 +4,7 @@ import pytest
 
 
 @pytest.fixture(autouse=True)
-def _setup_server_config_file(server_config): ...
+def _setup_server_config_file(authenticated_client): ...
 
 
 @pytest.fixture

--- a/qpc/tests/insights/conftest.py
+++ b/qpc/tests/insights/conftest.py
@@ -4,7 +4,7 @@ import pytest
 
 
 @pytest.fixture(autouse=True)
-def _setup_server_config_file(server_config):
+def _setup_server_config_file(authenticated_client):
     """Disable the server_config feature in conftest's root folder."""
     # We wanted the fixture to be widely available,
     # but only called when necessary as we use autouse flag

--- a/qpc/tests/report/conftest.py
+++ b/qpc/tests/report/conftest.py
@@ -4,7 +4,7 @@ import pytest
 
 
 @pytest.fixture(autouse=True)
-def _setup_server_config_file(server_config):
+def _setup_server_config_file(authenticated_client):
     """Disable the server_config feature in conftest's root folder."""
     # We wanted the fixture to be widely available,
     # but only called when necessary as we use autouse flag

--- a/qpc/tests/source/conftest.py
+++ b/qpc/tests/source/conftest.py
@@ -6,7 +6,7 @@ from qpc.cred import CREDENTIAL_URI
 
 
 @pytest.fixture(autouse=True)
-def _setup_server_config_file(server_config): ...
+def _setup_server_config_file(authenticated_client): ...
 
 
 @pytest.fixture

--- a/qpc/tests/test_qpc_utils.py
+++ b/qpc/tests/test_qpc_utils.py
@@ -12,7 +12,7 @@ class TestUtils:
         if not utils.QPC_CLIENT_TOKEN.exists():
             check_value = True
             expected_token = "100"
-            token_json = {"token": expected_token}
+            token_json = {utils.CLIENT_TOKEN_KEY: expected_token}
             utils.write_client_token(token_json)
         token = utils.read_client_token()
         assert isinstance(token, str)

--- a/qpc/tests/test_request.py
+++ b/qpc/tests/test_request.py
@@ -5,7 +5,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from qpc.request import request, version_tuple
-from qpc.utils import QPC_MIN_SERVER_VERSION
+from qpc.utils import CLIENT_TOKEN_TEST_VALUE, QPC_MIN_SERVER_VERSION
 
 
 def test_request_invalid_method(server_config, caplog):
@@ -20,7 +20,7 @@ def test_request_invalid_method(server_config, caplog):
 
 
 @pytest.mark.parametrize("method", ["GET", "DELETE", "PUT", "POST", "PATCH"])
-def test_request_methods(server_config, method):
+def test_request_methods(authenticated_client, method):
     """Test request with valid http methods."""
     with patch("qpc.request.perform_request") as mock_perform_request:
         request(method, "/path")
@@ -29,7 +29,7 @@ def test_request_methods(server_config, method):
             "http://127.0.0.1:8000/path",
             None,
             None,
-            {},
+            {"Authorization": f"Token {CLIENT_TOKEN_TEST_VALUE}"},
             QPC_MIN_SERVER_VERSION,
         )
 

--- a/qpc/utils.py
+++ b/qpc/utils.py
@@ -34,8 +34,11 @@ CONFIG_HOST_KEY = "host"
 CONFIG_PORT_KEY = "port"
 CONFIG_USE_HTTP = "use_http"
 CONFIG_SSL_VERIFY = "ssl_verify"
-CONFIG_REQUIRE_TOKEN = "require_token"
 CONFIG_SSO_HOST_KEY = "sso_host"
+
+CLIENT_TOKEN_KEY = "token"
+CLIENT_TOKEN_TEST_VALUE = "abc123"
+
 
 DEFAULT_HOST_INSIGHTS_CONFIG = "console.redhat.com"
 DEFAULT_PORT_INSIGHTS_CONFIG = 443
@@ -106,21 +109,9 @@ def read_client_token():
 
     try:
         token_json = json.loads(QPC_CLIENT_TOKEN.read_text())
-        return token_json.get("token")
+        return token_json.get(CLIENT_TOKEN_KEY)
     except json.decoder.JSONDecodeError:
         return None
-
-
-def read_require_auth():
-    """Determine if CLI should require token.
-
-    :returns: True is auth token required.
-    """
-    config = read_server_config()
-    if config is None:
-        # No configuration so True
-        return True
-    return config.get(CONFIG_REQUIRE_TOKEN)
 
 
 def read_insights_config():
@@ -157,7 +148,6 @@ def read_server_config():  # noqa: C901 PLR0911
     port = config.get(CONFIG_PORT_KEY)
     use_http = config.get(CONFIG_USE_HTTP)
     ssl_verify = config.get(CONFIG_SSL_VERIFY, False)
-    require_token = config.get(CONFIG_REQUIRE_TOKEN)
 
     host_empty = host is None or host == ""
     port_empty = port is None or port == ""
@@ -184,22 +174,11 @@ def read_server_config():  # noqa: C901 PLR0911
     if use_http is None:
         use_http = True
 
-    if require_token is None:
-        require_token = True
-
     if not isinstance(use_http, bool):
         logger.error(
             "Server config %s has invalid value for use_http %s",
             QPC_SERVER_CONFIG,
             use_http,
-        )
-        return None
-
-    if not isinstance(require_token, bool):
-        logger.error(
-            "Server config %s has invalid value for require_token %s",
-            QPC_SERVER_CONFIG,
-            require_token,
         )
         return None
 
@@ -232,7 +211,6 @@ def read_server_config():  # noqa: C901 PLR0911
         CONFIG_PORT_KEY: port,
         CONFIG_USE_HTTP: use_http,
         CONFIG_SSL_VERIFY: ssl_verify,
-        CONFIG_REQUIRE_TOKEN: require_token,
     }
 
 


### PR DESCRIPTION
This fixes DISCOVERY-815 .

Before this patch, when you run `dsc server config` for the first time ever, you get notification about config file not existing. That is triggered by `read_require_auth()` call. The easiest way is indenting this entire block - so when command is `server config`, we go straight to running a command. For anything else, we keep the current logic.

I've run all Camayoc cli tests using qpc with that patch and they passed.