### PR TITLE
fix: Tell user when insights report can't be generated due to source types

### DIFF
--- a/qpc/messages.py
+++ b/qpc/messages.py
@@ -209,6 +209,10 @@ REPORT_NO_DETAIL_REPORT_FOR_SJ = "No report detail available for scan job %s."
 REPORT_NO_DETAIL_REPORT_FOR_REPORT_ID = "No report detail available for report id %s."
 REPORT_NO_INSIGHTS_REPORT_FOR_SJ = "No Insights report available for scan job %s."
 REPORT_NO_INSIGHTS_REPORT_FOR_REPORT_ID = "Insights report %s does not exist."
+REPORT_NO_INSIGHTS_CLARIFICATION = (
+    "Insights report can be generated only if at least one source type "
+    "is network, satellite or vcenter."
+)
 REPORT_OUTPUT_CANNOT_BE_EMPTY = "%s cannot be empty string."
 REPORT_OUTPUT_IS_A_DIRECTORY = "%s %s was a directory."
 REPORT_DIRECTORY_DOES_NOT_EXIST = "The directory %s does not exist.  Cannot write here."

--- a/qpc/messages.py
+++ b/qpc/messages.py
@@ -211,7 +211,7 @@ REPORT_NO_INSIGHTS_REPORT_FOR_SJ = "No Insights report available for scan job %s
 REPORT_NO_INSIGHTS_REPORT_FOR_REPORT_ID = "Insights report %s does not exist."
 REPORT_NO_INSIGHTS_CLARIFICATION = (
     "Insights report can be generated only if at least one source type "
-    "is network, satellite or vcenter."
+    "is network, satellite, or vcenter."
 )
 REPORT_OUTPUT_CANNOT_BE_EMPTY = "%s cannot be empty string."
 REPORT_OUTPUT_IS_A_DIRECTORY = "%s %s was a directory."

--- a/qpc/messages.py
+++ b/qpc/messages.py
@@ -210,8 +210,8 @@ REPORT_NO_DETAIL_REPORT_FOR_REPORT_ID = "No report detail available for report i
 REPORT_NO_INSIGHTS_REPORT_FOR_SJ = "No Insights report available for scan job %s."
 REPORT_NO_INSIGHTS_REPORT_FOR_REPORT_ID = "Insights report %s does not exist."
 REPORT_NO_INSIGHTS_CLARIFICATION = (
-    "Insights report can be generated only if at least one source type "
-    "is network, satellite, or vcenter."
+    "The Insights report can only be generated if at least one source type is "
+    "network, satellite, or vcenter."
 )
 REPORT_OUTPUT_CANNOT_BE_EMPTY = "%s cannot be empty string."
 REPORT_OUTPUT_IS_A_DIRECTORY = "%s %s was a directory."

--- a/qpc/report/insights.py
+++ b/qpc/report/insights.py
@@ -120,7 +120,7 @@ class ReportInsightsCommand(CliCommand):
             response = request(
                 parser=self.parser,
                 method=GET,
-                path=f"{scan.SCAN_JOB_V2_URI}",
+                path=f"{scan.SCAN_JOB_URI}",
                 params={"report_id": self.args.report_id},
                 payload=None,
             )

--- a/qpc/scan/__init__.py
+++ b/qpc/scan/__init__.py
@@ -22,8 +22,8 @@ SCAN_STATUS_FAILED = "failed"
 
 SCAN_URI = "/api/v1/scans/"
 SCAN_BULK_DELETE_URI = "/api/v1/scans/bulk_delete/"
-SCAN_JOB_URI = "/api/v1/jobs/"
-SCAN_JOB_V2_URI = "/api/v2/jobs/"
+SCAN_JOB_V1_URI = "/api/v1/jobs/"
+SCAN_JOB_URI = "/api/v2/jobs/"
 
 SCAN_TYPE_CONNECT = "connect"
 SCAN_TYPE_INSPECT = "inspect"

--- a/qpc/scan/__init__.py
+++ b/qpc/scan/__init__.py
@@ -23,6 +23,7 @@ SCAN_STATUS_FAILED = "failed"
 SCAN_URI = "/api/v1/scans/"
 SCAN_BULK_DELETE_URI = "/api/v1/scans/bulk_delete/"
 SCAN_JOB_URI = "/api/v1/jobs/"
+SCAN_JOB_V2_URI = "/api/v2/jobs/"
 
 SCAN_TYPE_CONNECT = "connect"
 SCAN_TYPE_INSPECT = "inspect"

--- a/qpc/scan/cancel.py
+++ b/qpc/scan/cancel.py
@@ -29,7 +29,7 @@ class ScanCancelCommand(CliCommand):
             self.ACTION,
             subparsers.add_parser(self.ACTION),
             PUT,
-            scan.SCAN_JOB_URI,
+            scan.SCAN_JOB_V1_URI,
             [codes.ok],
         )
         self.parser.add_argument(

--- a/qpc/tests/report/test_report_insights.py
+++ b/qpc/tests/report/test_report_insights.py
@@ -17,7 +17,7 @@ from qpc.cli import CLI
 from qpc.release import VERSION
 from qpc.report import REPORT_URI
 from qpc.report.insights import ReportInsightsCommand
-from qpc.scan import SCAN_JOB_URI, SCAN_JOB_V2_URI
+from qpc.scan import SCAN_JOB_URI
 from qpc.tests.utilities import redirect_stdout
 from qpc.utils import create_tar_buffer, get_server_location
 
@@ -78,7 +78,7 @@ class TestReportInsights:
 
     def test_insights_report_as_json_report_id(self, caplog, fake_tarball):
         """Testing retreiving insights report as json with report id."""
-        scanjob_report_url = get_server_location() + SCAN_JOB_V2_URI + "?report_id=1"
+        scanjob_report_url = get_server_location() + SCAN_JOB_URI + "?report_id=1"
         scanjob_data = {"results": [{"sources": [{"source_type": "network"}]}]}
         get_report_url = get_server_location() + REPORT_URI + "1/insights/"
         get_report_json_data = {
@@ -163,7 +163,7 @@ class TestReportInsights:
     def test_insights_file_fails_to_write(self, file, caplog, fake_tarball):
         """Testing insights failure while writing to file."""
         file.side_effect = EnvironmentError()
-        scanjob_report_url = get_server_location() + SCAN_JOB_V2_URI + "?report_id=1"
+        scanjob_report_url = get_server_location() + SCAN_JOB_URI + "?report_id=1"
         scanjob_data = {"results": [{"sources": [{"source_type": "network"}]}]}
         get_report_url = get_server_location() + REPORT_URI + "1/insights/"
         get_report_json_data = {"id": 1, "report": [{"key": "value"}]}
@@ -236,7 +236,7 @@ class TestReportInsights:
 
     def test_insights_report_id_not_exist(self, caplog, fake_tarball):
         """Test insights with nonexistent report id."""
-        scanjob_report_url = get_server_location() + SCAN_JOB_V2_URI + "?report_id=1"
+        scanjob_report_url = get_server_location() + SCAN_JOB_URI + "?report_id=1"
         get_report_url = get_server_location() + REPORT_URI + "1/insights/"
         get_report_json_data = {"id": 1, "report": [{"key": "value"}]}
         test_dict = {fake_tarball: get_report_json_data}
@@ -289,7 +289,7 @@ class TestReportInsights:
 def test_insights_report_as_json_no_output_file(caplog, capsys, requests_mock):
     """Testing retrieving insights report as json without output file."""
     caplog.set_level("INFO")
-    scanjob_report_url = get_server_location() + SCAN_JOB_V2_URI + "?report_id=1"
+    scanjob_report_url = get_server_location() + SCAN_JOB_URI + "?report_id=1"
     scanjob_data = {"results": [{"sources": [{"source_type": "network"}]}]}
     requests_mock.get(
         scanjob_report_url,
@@ -364,7 +364,7 @@ def test_insights_not_available_report_id(caplog, capsys, requests_mock):
     using --report param.
     """
     caplog.set_level("INFO")
-    scanjob_report_url = get_server_location() + SCAN_JOB_V2_URI + "?report_id=1"
+    scanjob_report_url = get_server_location() + SCAN_JOB_URI + "?report_id=1"
     scanjob_data = {"results": [{"sources": [{"source_type": "ansible"}]}]}
     requests_mock.get(
         scanjob_report_url,
@@ -437,7 +437,7 @@ def test_insights_mix_sources_report_id(caplog, capsys, requests_mock):
     using --report param.
     """
     caplog.set_level("INFO")
-    scanjob_report_url = get_server_location() + SCAN_JOB_V2_URI + "?report_id=1"
+    scanjob_report_url = get_server_location() + SCAN_JOB_URI + "?report_id=1"
     scanjob_data = {
         "results": [
             {"sources": [{"source_type": "ansible"}, {"source_type": "satellite"}]}

--- a/qpc/tests/scan/test_scan_cancel.py
+++ b/qpc/tests/scan/test_scan_cancel.py
@@ -11,7 +11,7 @@ import requests_mock
 
 from qpc import messages
 from qpc.request import CONNECTION_ERROR_MSG
-from qpc.scan import SCAN_JOB_URI
+from qpc.scan import SCAN_JOB_V1_URI
 from qpc.scan.cancel import ScanCancelCommand
 from qpc.tests.utilities import DEFAULT_CONFIG, HushUpStderr, redirect_stdout
 from qpc.utils import get_server_location, write_server_config
@@ -48,7 +48,7 @@ class TestScanCancelCli:
     def test_cancel_scan_ssl_err(self):
         """Testing the cancel scan command with a connection error."""
         scan_out = StringIO()
-        url = get_server_location() + SCAN_JOB_URI + "1/cancel/"
+        url = get_server_location() + SCAN_JOB_V1_URI + "1/cancel/"
         with requests_mock.Mocker() as mocker:
             mocker.put(url, exc=requests.exceptions.SSLError)
 
@@ -61,7 +61,7 @@ class TestScanCancelCli:
     def test_cancel_scan_conn_err(self):
         """Testing the cancel scan command with a connection error."""
         scan_out = StringIO()
-        url = get_server_location() + SCAN_JOB_URI + "1/cancel/"
+        url = get_server_location() + SCAN_JOB_V1_URI + "1/cancel/"
         with requests_mock.Mocker() as mocker:
             mocker.put(url, exc=requests.exceptions.ConnectTimeout)
 
@@ -74,7 +74,7 @@ class TestScanCancelCli:
     def test_cancel_scan_internal_err(self):
         """Testing the cancel scan command with an internal error."""
         scan_out = StringIO()
-        url = get_server_location() + SCAN_JOB_URI + "1/cancel/"
+        url = get_server_location() + SCAN_JOB_V1_URI + "1/cancel/"
         with requests_mock.Mocker() as mocker:
             mocker.put(url, status_code=500, json={"error": ["Server Error"]})
 
@@ -86,7 +86,7 @@ class TestScanCancelCli:
 
     def test_cancel_scan_data(self, caplog):
         """Testing the cancel scan command successfully with stubbed data."""
-        url = get_server_location() + SCAN_JOB_URI + "1/cancel/"
+        url = get_server_location() + SCAN_JOB_V1_URI + "1/cancel/"
         with requests_mock.Mocker() as mocker:
             mocker.put(url, status_code=200, json=None)
 


### PR DESCRIPTION
All examples assume user is interacting with report that does not support insights report (so scan used sources of type {openshift, rhacs, ansible}).

Before the patch:

```
$ qpc -v report insights --report 2
Insights report 2 does not exist.
```

```
$ qpc -v report insights --scan-job 5
No Insights report available for scan job 5.
```

After this patch:

```
$ qpc -v report insights --report 2
Insights report 2 does not exist. Insights report can be generated only if at least one source type is network, satellite or vcenter.
```

```
$ qpc -v report insights --scan-job 5
No Insights report available for scan job 5. Insights report can be generated only if at least one source type is network, satellite or vcenter.
```

If user tries to download report by using non-existing report id or scan job id, clarification message is **not** shown (so, this patch does not change that case). 

There are two possible problems:

* When using a server **without** https://github.com/quipucords/quipucords/pull/2866 , API request to `/api/v2/jobs/?report_id=ID` will return **all** scanjobs. qpc will then make a decision based on whatever happens to be first item on the list. I assume we can guard against this with `min_server_version` when making a release and we don't need more extensive handling on qpc side.
* Removing a scan does not remove a report, so it is possible to request insights report for report without scanjobs, in which case we can't tell what source types were originally used. We still try to download it, we just don't show clarification in case of a problem. Since qpc does not provide a way to list reports, only scans and scanjobs, I don't think that's a large problem.

Relates to JIRA: DISCOVERY-791