### PR TITLE
fix: improve custom bin name handling for downstream builds

### DIFF
--- a/qpc.spec
+++ b/qpc.spec
@@ -41,6 +41,9 @@ qpc is the command-line client interface for the quipucords server.
 
 %build
 sed -i \
+  -e 's/^QPC_VAR_PROGRAM_NAME = os.environ.get("QPC_VAR_PROGRAM_NAME", "qpc")/QPC_VAR_PROGRAM_NAME = os.environ.get("QPC_VAR_PROGRAM_NAME", "%{binname}")/' \
+  %{_builddir}/qpc-%{version}/qpc/release.py
+sed -i \
   -e 's/^qpc = "qpc.__main__:main"$/%{binname} = "qpc.__main__:main"/' \
   %{_builddir}/qpc-%{version}/pyproject.toml
 %py3_build

--- a/qpc/release.py
+++ b/qpc/release.py
@@ -9,8 +9,12 @@ from . import __package__version__
 VERSION = __package__version__
 AUTHOR = "QPC Team"
 AUTHOR_EMAIL = "qpc@redhat.com"
+# BEGIN IMPORTANT NOTE: Do not change these lines.
+# Downstream builds may patch these lines to change the program name.
+# See also: https://issues.redhat.com/browse/DISCOVERY-785
 QPC_VAR_PROGRAM_NAME = os.environ.get("QPC_VAR_PROGRAM_NAME", "qpc")
 ENTRYPOINT = f"{QPC_VAR_PROGRAM_NAME}=qpc.__main__:main"
+# END IMPORTANT NOTE.
 URL = "https://github.com/quipucords/qpc"
 
 


### PR DESCRIPTION
I tested this by creating a build using a temporary additional commit containing the following patch:

```patch
--- a/qpc.spec
+++ b/qpc.spec
@@ -10,7 +10,7 @@
     %global python3_pkgversion 3.12
     %global __python3 /usr/bin/python3.12
 %endif
-%global binname qpc
+%global binname potato

 Name:           qpc
 Summary:        command-line client interface for quipucords
```

I waited for the packit/copr to complete a build for RHEL9, installed that build on a RHEL9 VM, and confirmed that the new bin name worked and was used in the help text where previously `qpc` was incorrectly used downstream.

```
[brasmith@rhel9 ~]$ potato
usage: potato [-h] [--version] [-v] {server,cred,source,scan,report,insights} ...

positional arguments:
  {server,cred,source,scan,report,insights}

options:
  -h, --help            show this help message and exit
  --version             show program's version number and exit
  -v                    Verbose mode. Use up to -vvvv for more verbosity.
[brasmith@rhel9 ~]$ potato server info
usage: potato server [-h] {config,login,logout,status} ...
potato server: error: argument action: invalid choice: 'info' (choose from 'config', 'login', 'logout', 'status')
```

See also additional commit in this branch for downstream builds:

https://pkgs.devel.redhat.com/cgit/rpms/discovery-cli/log/?h=private-brasmith-DISCOVERY-785

Relates to JIRA: DISCOVERY-785