### PR TITLE
Add support for the --sshkeyfile parameter

### DIFF
--- a/docs/_build/QPC_VAR_PROGRAM_NAME.1
+++ b/docs/_build/QPC_VAR_PROGRAM_NAME.1
@@ -152,7 +152,7 @@ When a scan runs, it uses a source that contains information such as the host na
 .sp
 To create a credential, supply the type of credential and supply SSH credentials as either a username\-password pair, a username\-key pair, or an access token. The QPC_VAR_PROJECT tool stores each set of credentials in a separate credential entry.
 .sp
-\fBQPC_VAR_PROGRAM_NAME cred add \-\-name=\fP \fIname\fP \fB\-\-type=\fP \fI(network | vcenter | satellite | openshift | rhacs | ansible)\fP \fB\-\-username=\fP \fIusername\fP \fB(\-\-password | \-\-sshkey\fP)** \fB[\-\-sshpassphrase]\fP \fB\-\-become\-method=\fP \fI(sudo | su | pbrun | pfexec | doas | dzdo | ksu | runas )\fP \fB\-\-become\-user=\fP \fIuser\fP \fB[\-\-become\-password]\fP \fB[\-\-token]\fP
+\fBQPC_VAR_PROGRAM_NAME cred add \-\-name=\fP \fIname\fP \fB\-\-type=\fP \fI(network | vcenter | satellite | openshift | rhacs | ansible)\fP \fB\-\-username=\fP \fIusername\fP (\fB\-\-password\fP | \fB\-\-sshkeyfile\fP \fI(ssh_keyfile | \-)\fP) \fB[\-\-sshpassphrase]\fP \fB\-\-become\-method=\fP \fI(sudo | su | pbrun | pfexec | doas | dzdo | ksu | runas )\fP \fB\-\-become\-user=\fP \fIuser\fP \fB[\-\-become\-password]\fP \fB[\-\-token]\fP
 .sp
 \fB\-\-name=name\fP
 .INDENT 0.0
@@ -178,21 +178,21 @@ Required for both password and SSH key authentication. Sets the username of the 
 \fB\-\-password\fP
 .INDENT 0.0
 .INDENT 3.5
-Prompts for the password for the \fB\-\-username\fP identity. Mutually exclusive with the \fB\-\-sshkey\fP and \fB\-\-token\fP options.
+Prompts for the password for the \fB\-\-username\fP identity. Mutually exclusive with the \fB\-\-sshkeyfile\fP and \fB\-\-token\fP options.
 .UNINDENT
 .UNINDENT
 .sp
-\fB\-\-sshkey\fP
+\fB\-\-sshkeyfile (ssh_keyfile | \-)\fP
 .INDENT 0.0
 .INDENT 3.5
-Prompts for the private SSH key for the \fB\-\-username\fP identity. Mutually exclusive with the \fB\-\-password\fP and \fB\-\-token\fP options.
+Reads the private SSH key for the \fB\-\-username\fP identity from the \fBssh_keyfile\fP path specified. If the \fBssh_keyfile\fP specified is \fB\-\fP, prompts for the private SSH key for the \fB\-\-username\fP identity. Mutually exclusive with the \fB\-\-password\fP and \fB\-\-token\fP options.
 .UNINDENT
 .UNINDENT
 .sp
 \fB\-\-sshpassphrase\fP
 .INDENT 0.0
 .INDENT 3.5
-Prompts for the passphrase to be used when connecting with an SSH key that requires a passphrase. Can only be used with the \fB\-\-sshkey\fP option.
+Prompts for the passphrase to be used when connecting with an SSH key that requires a passphrase. Can only be used with the \fB\-\-sshkeyfile\fP option.
 .UNINDENT
 .UNINDENT
 .sp
@@ -220,13 +220,13 @@ Prompts for the privilege escalation password to be used when running a network 
 \fB\-\-token\fP
 .INDENT 0.0
 .INDENT 3.5
-Prompts for the access token for authentication. Mutually exclusive with the \fB\-\-sshkey\fP and \fB\-\-password\fP options.
+Prompts for the access token for authentication. Mutually exclusive with the \fB\-\-sshkeyfile\fP and \fB\-\-password\fP options.
 .UNINDENT
 .UNINDENT
 .sp
 The information in a credential might change, including passwords, become passwords, SSH keys, the become_method, tokens or even the username. For example, your local security policies might require you to change passwords periodically. Use the \fBQPC_VAR_PROGRAM_NAME cred edit\fP command to change credential information. The parameters for \fBQPC_VAR_PROGRAM_NAME cred edit\fP are the same as those for \fBQPC_VAR_PROGRAM_NAME cred add\fP\&.
 .sp
-\fBQPC_VAR_PROGRAM_NAME cred edit \-\-name=\fP \fIname\fP \fB\-\-username=\fP \fIusername\fP \fB(\-\-password | \-\-sshkey **)\fP \fB[\-\-sshpassphrase]\fP \fB\-\-become\-method=\fP \fI(sudo | su | pbrun | pfexec | doas | dzdo | ksu | runas )\fP \fB\-\-become\-user=\fP \fIuser\fP \fB[\-\-become\-password]\fP \fB[\-\-token]\fP
+\fBQPC_VAR_PROGRAM_NAME cred edit \-\-name=\fP \fIname\fP \fB\-\-username=\fP \fIusername\fP (\fB\-\-password\fP | \fB\-\-sshkeyfile\fP \fI(ssh_keyfile | \-)\fP) \fB[\-\-sshpassphrase]\fP \fB\-\-become\-method=\fP \fI(sudo | su | pbrun | pfexec | doas | dzdo | ksu | runas )\fP \fB\-\-become\-user=\fP \fIuser\fP \fB[\-\-become\-password]\fP \fB[\-\-token]\fP
 .SS Listing and Showing Credentials
 .sp
 The \fBQPC_VAR_PROGRAM_NAME cred list\fP command returns the details for every credential that is configured for QPC_VAR_PROJECT. This output includes the name and username for each entry. Secret values such as passwords and tokens are never displated in the output.
@@ -885,13 +885,17 @@ Creating a new network type credential with a password
 .sp
 \fBQPC_VAR_PROGRAM_NAME cred add \-\-name net_cred \-\-type network \-\-username QPC_VAR_PROGRAM_NAME_user \-\-password\fP
 .IP \(bu 2
-Creating a new network type credential with an SSH key
+Creating a new network type credential with an SSH key from file
 .sp
-\fBQPC_VAR_PROGRAM_NAME cred add \-\-name net_cred4 \-\-type network \-\-username QPC_VAR_PROGRAM_NAME_user \-\-sshkey\fP
+\fBQPC_VAR_PROGRAM_NAME cred add \-\-name net_cred4 \-\-type network \-\-username QPC_VAR_PROGRAM_NAME_user \-\-sshkeyfile $HOME/.ssh/user_ssh_key\fP
 .IP \(bu 2
-Creating a new network type credential with an SSH key requiring a passphrase
+Creating a new network type credential and prompt for an SSH key
 .sp
-\fBQPC_VAR_PROGRAM_NAME cred add \-\-name net_cred5 \-\-type network \-\-username QPC_VAR_PROGRAM_NAME_user \-\-sshkey \-\-sshpassphrase\fP
+\fBQPC_VAR_PROGRAM_NAME cred add \-\-name net_cred4 \-\-type network \-\-username QPC_VAR_PROGRAM_NAME_user \-\-sshkeyfile \-\fP
+.IP \(bu 2
+Creating a new network type credential with an SSH key from file requiring a passphrase
+.sp
+\fBQPC_VAR_PROGRAM_NAME cred add \-\-name net_cred5 \-\-type network \-\-username QPC_VAR_PROGRAM_NAME_user \-\-sshkeyfile $HOME/.ssh/user_ssh_key \-\-sshpassphrase\fP
 .IP \(bu 2
 Creating a new openshift type credential with a token
 .sp

--- a/docs/_build/man-qpc.rst
+++ b/docs/_build/man-qpc.rst
@@ -134,7 +134,7 @@ Creating and Editing Credentials
 
 To create a credential, supply the type of credential and supply SSH credentials as either a username-password pair, a username-key pair, or an access token. The Quipucords tool stores each set of credentials in a separate credential entry.
 
-**qpc cred add --name=** *name* **--type=** *(network | vcenter | satellite | openshift | rhacs | ansible)* **--username=** *username* **(--password | --sshkey**)** **[--sshpassphrase]** **--become-method=** *(sudo | su | pbrun | pfexec | doas | dzdo | ksu | runas )* **--become-user=** *user* **[--become-password]** **[--token]**
+**qpc cred add --name=** *name* **--type=** *(network | vcenter | satellite | openshift | rhacs | ansible)* **--username=** *username* (**--password** | **--sshkeyfile** *(ssh_keyfile | -)*) **[--sshpassphrase]** **--become-method=** *(sudo | su | pbrun | pfexec | doas | dzdo | ksu | runas )* **--become-user=** *user* **[--become-password]** **[--token]**
 
 ``--name=name``
 
@@ -150,15 +150,15 @@ To create a credential, supply the type of credential and supply SSH credentials
 
 ``--password``
 
-  Prompts for the password for the ``--username`` identity. Mutually exclusive with the ``--sshkey`` and ``--token`` options.
+  Prompts for the password for the ``--username`` identity. Mutually exclusive with the ``--sshkeyfile`` and ``--token`` options.
 
-``--sshkey``
+``--sshkeyfile (ssh_keyfile | -)``
 
-  Prompts for the private SSH key for the ``--username`` identity. Mutually exclusive with the ``--password`` and ``--token`` options.
+  Reads the private SSH key for the ``--username`` identity from the ``ssh_keyfile`` path specified. If the ``ssh_keyfile`` specified is ``-``, prompts for the private SSH key for the ``--username`` identity. Mutually exclusive with the ``--password`` and ``--token`` options.
 
 ``--sshpassphrase``
 
-  Prompts for the passphrase to be used when connecting with an SSH key that requires a passphrase. Can only be used with the ``--sshkey`` option.
+  Prompts for the passphrase to be used when connecting with an SSH key that requires a passphrase. Can only be used with the ``--sshkeyfile`` option.
 
 ``--become-method=become_method``
 
@@ -174,11 +174,11 @@ To create a credential, supply the type of credential and supply SSH credentials
 
 ``--token``
 
-  Prompts for the access token for authentication. Mutually exclusive with the ``--sshkey`` and ``--password`` options.
+  Prompts for the access token for authentication. Mutually exclusive with the ``--sshkeyfile`` and ``--password`` options.
 
 The information in a credential might change, including passwords, become passwords, SSH keys, the become_method, tokens or even the username. For example, your local security policies might require you to change passwords periodically. Use the ``qpc cred edit`` command to change credential information. The parameters for ``qpc cred edit`` are the same as those for ``qpc cred add``.
 
-**qpc cred edit --name=** *name* **--username=** *username* **(--password | --sshkey **)** **[--sshpassphrase]** **--become-method=** *(sudo | su | pbrun | pfexec | doas | dzdo | ksu | runas )* **--become-user=** *user* **[--become-password]** **[--token]**
+**qpc cred edit --name=** *name* **--username=** *username* (**--password** | **--sshkeyfile** *(ssh_keyfile | -)*) **[--sshpassphrase]** **--become-method=** *(sudo | su | pbrun | pfexec | doas | dzdo | ksu | runas )* **--become-user=** *user* **[--become-password]** **[--token]**
 
 Listing and Showing Credentials
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -704,13 +704,17 @@ Examples
 
   ``qpc cred add --name net_cred --type network --username qpc_user --password``
 
-* Creating a new network type credential with an SSH key
+* Creating a new network type credential with an SSH key from file
 
-  ``qpc cred add --name net_cred4 --type network --username qpc_user --sshkey``
+  ``qpc cred add --name net_cred4 --type network --username qpc_user --sshkeyfile $HOME/.ssh/user_ssh_key``
 
-* Creating a new network type credential with an SSH key requiring a passphrase
+* Creating a new network type credential and prompt for an SSH key
 
-  ``qpc cred add --name net_cred5 --type network --username qpc_user --sshkey --sshpassphrase``
+  ``qpc cred add --name net_cred4 --type network --username qpc_user --sshkeyfile -``
+
+* Creating a new network type credential with an SSH key from file requiring a passphrase
+
+  ``qpc cred add --name net_cred5 --type network --username qpc_user --sshkeyfile $HOME/.ssh/user_ssh_key --sshpassphrase``
 
 * Creating a new openshift type credential with a token
 

--- a/docs/_build/qpc.1
+++ b/docs/_build/qpc.1
@@ -27,7 +27,7 @@ level margin: \\n[rst2man-indent\\n[rst2man-indent-level]]
 .\" new: \\n[rst2man-indent\\n[rst2man-indent-level]]
 .in \\n[rst2man-indent\\n[rst2man-indent-level]]u
 ..
-.TH "qpc" "1" "January 03, 2025" "" "qpc"
+.TH "qpc" "1" "May 07, 2025" "" "qpc"
 .SH NAME
 .sp
 qpc \- Inspect and report on product entitlement metadata from various sources, including networks and systems management solutions.
@@ -152,7 +152,7 @@ When a scan runs, it uses a source that contains information such as the host na
 .sp
 To create a credential, supply the type of credential and supply SSH credentials as either a username\-password pair, a username\-key pair, or an access token. The Quipucords tool stores each set of credentials in a separate credential entry.
 .sp
-\fBqpc cred add \-\-name=\fP \fIname\fP \fB\-\-type=\fP \fI(network | vcenter | satellite | openshift | rhacs | ansible)\fP \fB\-\-username=\fP \fIusername\fP \fB(\-\-password | \-\-sshkey\fP)** \fB[\-\-sshpassphrase]\fP \fB\-\-become\-method=\fP \fI(sudo | su | pbrun | pfexec | doas | dzdo | ksu | runas )\fP \fB\-\-become\-user=\fP \fIuser\fP \fB[\-\-become\-password]\fP \fB[\-\-token]\fP
+\fBqpc cred add \-\-name=\fP \fIname\fP \fB\-\-type=\fP \fI(network | vcenter | satellite | openshift | rhacs | ansible)\fP \fB\-\-username=\fP \fIusername\fP (\fB\-\-password\fP | \fB\-\-sshkeyfile\fP \fI(ssh_keyfile | \-)\fP) \fB[\-\-sshpassphrase]\fP \fB\-\-become\-method=\fP \fI(sudo | su | pbrun | pfexec | doas | dzdo | ksu | runas )\fP \fB\-\-become\-user=\fP \fIuser\fP \fB[\-\-become\-password]\fP \fB[\-\-token]\fP
 .sp
 \fB\-\-name=name\fP
 .INDENT 0.0
@@ -178,21 +178,21 @@ Required for both password and SSH key authentication. Sets the username of the 
 \fB\-\-password\fP
 .INDENT 0.0
 .INDENT 3.5
-Prompts for the password for the \fB\-\-username\fP identity. Mutually exclusive with the \fB\-\-sshkey\fP and \fB\-\-token\fP options.
+Prompts for the password for the \fB\-\-username\fP identity. Mutually exclusive with the \fB\-\-sshkeyfile\fP and \fB\-\-token\fP options.
 .UNINDENT
 .UNINDENT
 .sp
-\fB\-\-sshkey\fP
+\fB\-\-sshkeyfile (ssh_keyfile | \-)\fP
 .INDENT 0.0
 .INDENT 3.5
-Prompts for the private SSH key for the \fB\-\-username\fP identity. Mutually exclusive with the \fB\-\-password\fP and \fB\-\-token\fP options.
+Reads the private SSH key for the \fB\-\-username\fP identity from the \fBssh_keyfile\fP path specified. If the \fBssh_keyfile\fP specified is \fB\-\fP, prompts for the private SSH key for the \fB\-\-username\fP identity. Mutually exclusive with the \fB\-\-password\fP and \fB\-\-token\fP options.
 .UNINDENT
 .UNINDENT
 .sp
 \fB\-\-sshpassphrase\fP
 .INDENT 0.0
 .INDENT 3.5
-Prompts for the passphrase to be used when connecting with an SSH key that requires a passphrase. Can only be used with the \fB\-\-sshkey\fP option.
+Prompts for the passphrase to be used when connecting with an SSH key that requires a passphrase. Can only be used with the \fB\-\-sshkeyfile\fP option.
 .UNINDENT
 .UNINDENT
 .sp
@@ -220,13 +220,13 @@ Prompts for the privilege escalation password to be used when running a network 
 \fB\-\-token\fP
 .INDENT 0.0
 .INDENT 3.5
-Prompts for the access token for authentication. Mutually exclusive with the \fB\-\-sshkey\fP and \fB\-\-password\fP options.
+Prompts for the access token for authentication. Mutually exclusive with the \fB\-\-sshkeyfile\fP and \fB\-\-password\fP options.
 .UNINDENT
 .UNINDENT
 .sp
 The information in a credential might change, including passwords, become passwords, SSH keys, the become_method, tokens or even the username. For example, your local security policies might require you to change passwords periodically. Use the \fBqpc cred edit\fP command to change credential information. The parameters for \fBqpc cred edit\fP are the same as those for \fBqpc cred add\fP\&.
 .sp
-\fBqpc cred edit \-\-name=\fP \fIname\fP \fB\-\-username=\fP \fIusername\fP \fB(\-\-password | \-\-sshkey **)\fP \fB[\-\-sshpassphrase]\fP \fB\-\-become\-method=\fP \fI(sudo | su | pbrun | pfexec | doas | dzdo | ksu | runas )\fP \fB\-\-become\-user=\fP \fIuser\fP \fB[\-\-become\-password]\fP \fB[\-\-token]\fP
+\fBqpc cred edit \-\-name=\fP \fIname\fP \fB\-\-username=\fP \fIusername\fP (\fB\-\-password\fP | \fB\-\-sshkeyfile\fP \fI(ssh_keyfile | \-)\fP) \fB[\-\-sshpassphrase]\fP \fB\-\-become\-method=\fP \fI(sudo | su | pbrun | pfexec | doas | dzdo | ksu | runas )\fP \fB\-\-become\-user=\fP \fIuser\fP \fB[\-\-become\-password]\fP \fB[\-\-token]\fP
 .SS Listing and Showing Credentials
 .sp
 The \fBqpc cred list\fP command returns the details for every credential that is configured for Quipucords. This output includes the name and username for each entry. Secret values such as passwords and tokens are never displated in the output.
@@ -885,13 +885,17 @@ Creating a new network type credential with a password
 .sp
 \fBqpc cred add \-\-name net_cred \-\-type network \-\-username qpc_user \-\-password\fP
 .IP \(bu 2
-Creating a new network type credential with an SSH key
+Creating a new network type credential with an SSH key from file
 .sp
-\fBqpc cred add \-\-name net_cred4 \-\-type network \-\-username qpc_user \-\-sshkey\fP
+\fBqpc cred add \-\-name net_cred4 \-\-type network \-\-username qpc_user \-\-sshkeyfile $HOME/.ssh/user_ssh_key\fP
 .IP \(bu 2
-Creating a new network type credential with an SSH key requiring a passphrase
+Creating a new network type credential and prompt for an SSH key
 .sp
-\fBqpc cred add \-\-name net_cred5 \-\-type network \-\-username qpc_user \-\-sshkey \-\-sshpassphrase\fP
+\fBqpc cred add \-\-name net_cred4 \-\-type network \-\-username qpc_user \-\-sshkeyfile \-\fP
+.IP \(bu 2
+Creating a new network type credential with an SSH key from file requiring a passphrase
+.sp
+\fBqpc cred add \-\-name net_cred5 \-\-type network \-\-username qpc_user \-\-sshkeyfile $HOME/.ssh/user_ssh_key \-\-sshpassphrase\fP
 .IP \(bu 2
 Creating a new openshift type credential with a token
 .sp

--- a/docs/source/man-template.rst
+++ b/docs/source/man-template.rst
@@ -134,7 +134,7 @@ Creating and Editing Credentials
 
 To create a credential, supply the type of credential and supply SSH credentials as either a username-password pair, a username-key pair, or an access token. The QPC_VAR_PROJECT tool stores each set of credentials in a separate credential entry.
 
-**QPC_VAR_PROGRAM_NAME cred add --name=** *name* **--type=** *(network | vcenter | satellite | openshift | rhacs | ansible)* **--username=** *username* **(--password | --sshkey**)** **[--sshpassphrase]** **--become-method=** *(sudo | su | pbrun | pfexec | doas | dzdo | ksu | runas )* **--become-user=** *user* **[--become-password]** **[--token]**
+**QPC_VAR_PROGRAM_NAME cred add --name=** *name* **--type=** *(network | vcenter | satellite | openshift | rhacs | ansible)* **--username=** *username* (**--password** | **--sshkeyfile** *(ssh_keyfile | -)*) **[--sshpassphrase]** **--become-method=** *(sudo | su | pbrun | pfexec | doas | dzdo | ksu | runas )* **--become-user=** *user* **[--become-password]** **[--token]**
 
 ``--name=name``
 
@@ -150,15 +150,15 @@ To create a credential, supply the type of credential and supply SSH credentials
 
 ``--password``
 
-  Prompts for the password for the ``--username`` identity. Mutually exclusive with the ``--sshkey`` and ``--token`` options.
+  Prompts for the password for the ``--username`` identity. Mutually exclusive with the ``--sshkeyfile`` and ``--token`` options.
 
-``--sshkey``
+``--sshkeyfile (ssh_keyfile | -)``
 
-  Prompts for the private SSH key for the ``--username`` identity. Mutually exclusive with the ``--password`` and ``--token`` options.
+  Reads the private SSH key for the ``--username`` identity from the ``ssh_keyfile`` path specified. If the ``ssh_keyfile`` specified is ``-``, prompts for the private SSH key for the ``--username`` identity. Mutually exclusive with the ``--password`` and ``--token`` options.
 
 ``--sshpassphrase``
 
-  Prompts for the passphrase to be used when connecting with an SSH key that requires a passphrase. Can only be used with the ``--sshkey`` option.
+  Prompts for the passphrase to be used when connecting with an SSH key that requires a passphrase. Can only be used with the ``--sshkeyfile`` option.
 
 ``--become-method=become_method``
 
@@ -174,11 +174,11 @@ To create a credential, supply the type of credential and supply SSH credentials
 
 ``--token``
 
-  Prompts for the access token for authentication. Mutually exclusive with the ``--sshkey`` and ``--password`` options.
+  Prompts for the access token for authentication. Mutually exclusive with the ``--sshkeyfile`` and ``--password`` options.
 
 The information in a credential might change, including passwords, become passwords, SSH keys, the become_method, tokens or even the username. For example, your local security policies might require you to change passwords periodically. Use the ``QPC_VAR_PROGRAM_NAME cred edit`` command to change credential information. The parameters for ``QPC_VAR_PROGRAM_NAME cred edit`` are the same as those for ``QPC_VAR_PROGRAM_NAME cred add``.
 
-**QPC_VAR_PROGRAM_NAME cred edit --name=** *name* **--username=** *username* **(--password | --sshkey **)** **[--sshpassphrase]** **--become-method=** *(sudo | su | pbrun | pfexec | doas | dzdo | ksu | runas )* **--become-user=** *user* **[--become-password]** **[--token]**
+**QPC_VAR_PROGRAM_NAME cred edit --name=** *name* **--username=** *username* (**--password** | **--sshkeyfile** *(ssh_keyfile | -)*) **[--sshpassphrase]** **--become-method=** *(sudo | su | pbrun | pfexec | doas | dzdo | ksu | runas )* **--become-user=** *user* **[--become-password]** **[--token]**
 
 Listing and Showing Credentials
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -704,13 +704,17 @@ Examples
 
   ``QPC_VAR_PROGRAM_NAME cred add --name net_cred --type network --username QPC_VAR_PROGRAM_NAME_user --password``
 
-* Creating a new network type credential with an SSH key
+* Creating a new network type credential with an SSH key from file
 
-  ``QPC_VAR_PROGRAM_NAME cred add --name net_cred4 --type network --username QPC_VAR_PROGRAM_NAME_user --sshkey``
+  ``QPC_VAR_PROGRAM_NAME cred add --name net_cred4 --type network --username QPC_VAR_PROGRAM_NAME_user --sshkeyfile $HOME/.ssh/user_ssh_key``
 
-* Creating a new network type credential with an SSH key requiring a passphrase
+* Creating a new network type credential and prompt for an SSH key
 
-  ``QPC_VAR_PROGRAM_NAME cred add --name net_cred5 --type network --username QPC_VAR_PROGRAM_NAME_user --sshkey --sshpassphrase``
+  ``QPC_VAR_PROGRAM_NAME cred add --name net_cred4 --type network --username QPC_VAR_PROGRAM_NAME_user --sshkeyfile -``
+
+* Creating a new network type credential with an SSH key from file requiring a passphrase
+
+  ``QPC_VAR_PROGRAM_NAME cred add --name net_cred5 --type network --username QPC_VAR_PROGRAM_NAME_user --sshkeyfile $HOME/.ssh/user_ssh_key --sshpassphrase``
 
 * Creating a new openshift type credential with a token
 

--- a/qpc/cred/add.py
+++ b/qpc/cred/add.py
@@ -68,10 +68,10 @@ class CredAddCommand(CliCommand):
             help=_(messages.CRED_PWD_HELP),
         )
         group.add_argument(
-            "--sshkey",
-            dest="ssh_key",
-            action="store_true",
-            help=_(messages.CRED_SSH_KEY_HELP),
+            "--sshkeyfile",
+            dest="ssh_keyfile",
+            metavar="SSH_KEYFILE",
+            help=_(messages.CRED_SSH_KEYFILE_HELP),
         )
         group.add_argument(
             "--token",

--- a/qpc/cred/add.py
+++ b/qpc/cred/add.py
@@ -83,7 +83,7 @@ class CredAddCommand(CliCommand):
             "--sshpassphrase",
             dest="ssh_passphrase",
             action="store_true",
-            help=_(messages.CRED_SSH_PSPH_HELP),
+            help=_(messages.CRED_SSH_PASSPHRASE_HELP),
         )
         self.parser.add_argument(
             "--become-method",

--- a/qpc/cred/edit.py
+++ b/qpc/cred/edit.py
@@ -73,7 +73,7 @@ class CredEditCommand(CliCommand):
             "--sshpassphrase",
             dest="ssh_passphrase",
             action="store_true",
-            help=_(messages.CRED_SSH_PSPH_HELP),
+            help=_(messages.CRED_SSH_PASSPHRASE_HELP),
         )
         self.parser.add_argument(
             "--become-method",

--- a/qpc/cred/edit.py
+++ b/qpc/cred/edit.py
@@ -64,10 +64,10 @@ class CredEditCommand(CliCommand):
             help=_(messages.CRED_TOKEN_HELP),
         )
         group.add_argument(
-            "--sshkey",
-            dest="ssh_key",
-            action="store_true",
-            help=_(messages.CRED_SSH_KEY_HELP),
+            "--sshkeyfile",
+            dest="ssh_keyfile",
+            metavar="SSH_KEYFILE",
+            help=_(messages.CRED_SSH_KEYFILE_HELP),
         )
         self.parser.add_argument(
             "--sshpassphrase",
@@ -102,7 +102,7 @@ class CredEditCommand(CliCommand):
         if not (
             self.args.username
             or self.args.password
-            or self.args.ssh_key
+            or self.args.ssh_keyfile
             or self.args.ssh_passphrase
             or self.args.become_method
             or self.args.become_user

--- a/qpc/cred/utils.py
+++ b/qpc/cred/utils.py
@@ -64,27 +64,33 @@ def _get_attribute_value(attribute, prompt, args, req_payload, add_none):
 def _get_ssh_key_value(args, req_payload, add_none):
     """Collect the ssh_key value and place in credential dictionary."""
     if "ssh_keyfile" in args and args.ssh_keyfile:
-        if args.ssh_keyfile == "-":
-            if sys.stdin.isatty():
-                print(_(messages.SSH_KEY))
-                pass_prompt = get_multiline_pass(prompt=f"{messages.SSH_KEY_PROMPT}")
-                check_if_prompt_is_not_empty(pass_prompt)
+        try:
+            if args.ssh_keyfile == "-":
+                if sys.stdin.isatty():
+                    print(_(messages.SSH_KEY))
+                    pass_prompt = get_multiline_pass(
+                        prompt=f"{messages.SSH_KEY_PROMPT}"
+                    )
+                    check_if_prompt_is_not_empty(pass_prompt)
+                else:
+                    pass_prompt = "".join(sys.stdin.readlines())
+                req_payload["ssh_key"] = pass_prompt
             else:
-                pass_prompt = "".join(sys.stdin.readlines())
-            req_payload["ssh_key"] = pass_prompt
-        else:
-            try:
-                req_payload["ssh_key"] = Path(args.ssh_keyfile).read_text()
-            except FileNotFoundError:
-                logger.error(
-                    _(messages.CRED_SSH_KEYFILE_DOES_NOT_EXIST), args.ssh_keyfile
-                )
-                sys.exit(1)
-            except PermissionError:
-                logger.error(
-                    _(messages.CRED_SSH_KEYFILE_FAILED_TO_READ), args.ssh_keyfile
-                )
-                sys.exit(1)
+                try:
+                    req_payload["ssh_key"] = Path(args.ssh_keyfile).read_text()
+                except FileNotFoundError:
+                    logger.error(
+                        _(messages.CRED_SSH_KEYFILE_DOES_NOT_EXIST), args.ssh_keyfile
+                    )
+                    sys.exit(1)
+                except PermissionError:
+                    logger.error(
+                        _(messages.CRED_SSH_KEYFILE_FAILED_TO_READ), args.ssh_keyfile
+                    )
+                    sys.exit(1)
+        except UnicodeDecodeError:
+            logger.error(messages.CRED_SSH_KEY_CANNOT_BE_DECODED)
+            sys.exit(1)
 
     elif add_none:
         req_payload["ssh_key"] = None

--- a/qpc/messages.py
+++ b/qpc/messages.py
@@ -16,6 +16,7 @@ CRED_SSH_KEYFILE_DOES_NOT_EXIST = (
     "The SSH Private Key file %s specified does not exist."
 )
 CRED_SSH_KEYFILE_FAILED_TO_READ = "Failed to read the SSH Private Key file %s."
+CRED_SSH_KEY_CANNOT_BE_DECODED = "The SSH Private Key specified cannot be decoded."
 CRED_SSH_PASSPHRASE_HELP = (
     "SSH passphrase for authenticating against the target system."
 )

--- a/qpc/messages.py
+++ b/qpc/messages.py
@@ -16,7 +16,9 @@ CRED_SSH_KEYFILE_DOES_NOT_EXIST = (
     "The SSH Private Key file %s specified does not exist."
 )
 CRED_SSH_KEYFILE_FAILED_TO_READ = "Failed to read the SSH Private Key file %s."
-CRED_SSH_PSPH_HELP = "SSH passphrase for authenticating against the target system."
+CRED_SSH_PASSPHRASE_HELP = (
+    "SSH passphrase for authenticating against the target system."
+)
 CRED_CLEAR_ALL_HELP = "Remove all credentials."
 
 CRED_ADDED = 'Credential "%s" was added.'

--- a/qpc/messages.py
+++ b/qpc/messages.py
@@ -11,8 +11,11 @@ CRED_TYPE_FILTER_HELP = (
 )
 CRED_USER_HELP = "User name for authenticating against the target system."
 CRED_PWD_HELP = "Password for authenticating against the target system."
-CRED_SSH_FILE_HELP = "File that contains the SSH key."
-CRED_SSH_KEY_HELP = "The SSH Private Key."
+CRED_SSH_KEYFILE_HELP = "The SSH Private Key file path or - for stdin."
+CRED_SSH_KEYFILE_DOES_NOT_EXIST = (
+    "The SSH Private Key file %s specified does not exist."
+)
+CRED_SSH_KEYFILE_FAILED_TO_READ = "Failed to read the SSH Private Key file %s."
 CRED_SSH_PSPH_HELP = "SSH passphrase for authenticating against the target system."
 CRED_CLEAR_ALL_HELP = "Remove all credentials."
 
@@ -259,7 +262,7 @@ PASSWORD_PROMPT_WITH_NO_TTY = (
 )
 CONN_PASSWORD = "Provide a connection password."
 SSH_PASSPHRASE = "Provide a passphrase for the SSH Key."
-SSH_KEY = "Provide a Private SSH Key followed by a Control-D."
+SSH_KEY = "Provide a Private SSH Key followed by a Control-D on a new-line."
 SSH_KEY_PROMPT = "Private SSH Key: "
 BECOME_PASSWORD = (
     "Provide a privilege escalation password to be used when running a network scan."

--- a/qpc/tests/cred/test_openshift_cred_add.py
+++ b/qpc/tests/cred/test_openshift_cred_add.py
@@ -91,7 +91,7 @@ class TestOpenShiftAddCredential:
             CLI().main()
         out, err = capsys.readouterr()
         assert out == ""
-        assert "one of the arguments --password --sshkey --token is required" in err
+        assert "one of the arguments --password --sshkeyfile --token is required" in err
 
     def test_add_no_name(
         self,


### PR DESCRIPTION
 - Support the --sshkeyfile argument for allowing users to input the ssh key by filename.  Allow for - as filename to take stdin as it would behave today for --sshkey
 - Drop support for the --sshkey argument.


Draft for now ...

to do's:
- [x] additional tests
- [x] code coverage
- [x] man page update

Solves: [DISCOVERY-811](https://issues.redhat.com/browse/DISCOVERY-811)
Requires: [camayoc/582](https://github.com/quipucords/camayoc/pull/582)

