### PR TITLE
build: update minimum uv from 0.6 to 0.7 (no max version)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,7 @@ default-groups = [
     "dev",
     "build",
 ]
-required-version = ">=0.6.11,<0.7"
+required-version = ">=0.7"
 
 [tool.hatch.build.targets.sdist]
 exclude = [


### PR DESCRIPTION
Corresponds with https://github.com/quipucords/quipucords/pull/2977 update to use uv 0.7+.