### PR TITLE
feat(source): add proxy support

### DIFF
--- a/docs/_build/QPC_VAR_PROGRAM_NAME.1
+++ b/docs/_build/QPC_VAR_PROGRAM_NAME.1
@@ -282,7 +282,7 @@ When you configure a scan, it contains references to one or more sources, includ
 .sp
 To create a source, supply the type of source with the \fBtype\fP option, one or more host names or IP addresses to connect to with the \fB\-\-hosts\fP option, and the credentials needed to access those systems with the \fB\-\-cred\fP option. The \fBQPC_VAR_PROGRAM_NAME source\fP command allows multiple entries for the \fBhosts\fP and \fBcred\fP options. Therefore, a single source can access a collection of servers and subnets as needed to create an accurate and complete scan.
 .sp
-\fBQPC_VAR_PROGRAM_NAME source add \-\-name=\fP \fIname\fP  \fB\-\-type=\fP \fI(network | vcenter | satellite | openshift | rhacs | ansible)\fP \fB\-\-hosts\fP \fIip_address\fP \fB\-\-cred\fP \fIcredential\fP \fB[\-\-exclude\-hosts\fP \fIip_address\fP \fB]\fP \fB[\-\-port=\fP \fIport\fP \fB]\fP \fB[\-\-use\-paramiko=\fP \fI(True | False)\fP \fB]\fP \fB[\-\-ssl\-cert\-verify=\fP \fI(True | False)\fP \fB]\fP \fB[\-\-ssl\-protocol=\fP \fIprotocol\fP \fB]\fP \fB[\-\-disable\-ssl=\fP \fI(True | False)\fP \fB]\fP
+\fBQPC_VAR_PROGRAM_NAME source add \-\-name=\fP \fIname\fP  \fB\-\-type=\fP \fI(network | vcenter | satellite | openshift | rhacs | ansible)\fP \fB\-\-hosts\fP \fIip_address\fP \fB\-\-cred\fP \fIcredential\fP \fB[\-\-exclude\-hosts\fP \fIip_address\fP \fB]\fP \fB[\-\-port=\fP \fIport\fP \fB]\fP \fB[\-\-use\-paramiko=\fP \fI(True | False)\fP \fB]\fP \fB[\-\-ssl\-cert\-verify=\fP \fI(True | False)\fP \fB]\fP \fB[\-\-ssl\-protocol=\fP \fIprotocol\fP \fB]\fP \fB[\-\-disable\-ssl=\fP \fI(True | False)\fP \fB]\fP \fB[\-\-proxy\-url=\fP \fIproxy url\fP \fB]\fP
 .sp
 \fB\-\-name=name\fP
 .INDENT 0.0
@@ -375,6 +375,14 @@ Optional. Determines the SSL protocol to be used for a secure connection during 
 .INDENT 0.0
 .INDENT 3.5
 Optional. Determines whether SSL communication will be disabled for the scan.
+.UNINDENT
+.UNINDENT
+.sp
+\fB\-\-proxy\-url=url\fP
+.INDENT 0.0
+.INDENT 3.5
+Optional. Sets a proxy server to be used for connecting to the source. This can be helpful in environments that require outbound requests to go through a proxy.
+Use the format protocol://host:port.
 .UNINDENT
 .UNINDENT
 .sp
@@ -952,6 +960,10 @@ Creating a new network source with an excluded host
 Creating a new vcenter source specifying a SSL protocol
 .sp
 \fBQPC_VAR_PROGRAM_NAME source add \-\-name vcenter_source \-\-type vcenter \-\-hosts 1.192.0.19 \-\-cred vcenter_cred \-\-ssl\-protocol SSLv23\fP
+.IP \(bu 2
+Creating a new openShift source using a proxy
+.sp
+\fBQPC_VAR_PROGRAM_NAME source add \-\-name ocp_source \-\-type openshift \-\-hosts api.openshift.example.com \-\-cred ocp_cred \-\-proxy\-url http://proxy.example.com:3128\fP
 .IP \(bu 2
 Creating a new satellite source disabling SSL
 .sp

--- a/docs/_build/man-qpc.rst
+++ b/docs/_build/man-qpc.rst
@@ -232,7 +232,7 @@ Creating and Editing Sources
 
 To create a source, supply the type of source with the ``type`` option, one or more host names or IP addresses to connect to with the ``--hosts`` option, and the credentials needed to access those systems with the ``--cred`` option. The ``qpc source`` command allows multiple entries for the ``hosts`` and ``cred`` options. Therefore, a single source can access a collection of servers and subnets as needed to create an accurate and complete scan.
 
-**qpc source add --name=** *name*  **--type=** *(network | vcenter | satellite | openshift | rhacs | ansible)* **--hosts** *ip_address* **--cred** *credential* **[--exclude-hosts** *ip_address* **]** **[--port=** *port* **]** **[--use-paramiko=** *(True | False)* **]** **[--ssl-cert-verify=** *(True | False)* **]** **[--ssl-protocol=** *protocol* **]** **[--disable-ssl=** *(True | False)* **]**
+**qpc source add --name=** *name*  **--type=** *(network | vcenter | satellite | openshift | rhacs | ansible)* **--hosts** *ip_address* **--cred** *credential* **[--exclude-hosts** *ip_address* **]** **[--port=** *port* **]** **[--use-paramiko=** *(True | False)* **]** **[--ssl-cert-verify=** *(True | False)* **]** **[--ssl-protocol=** *protocol* **]** **[--disable-ssl=** *(True | False)* **]** **[--proxy-url=** *proxy url* **]**
 
 ``--name=name``
 
@@ -295,6 +295,11 @@ To create a source, supply the type of source with the ``type`` option, one or m
 ``--disable-ssl=(True | False)``
 
   Optional. Determines whether SSL communication will be disabled for the scan.
+
+``--proxy-url=url``
+
+  Optional. Sets a proxy server to be used for connecting to the source. This can be helpful in environments that require outbound requests to go through a proxy.
+  Use the format protocol://host:port.
 
 The information in a source might change as the structure of the network changes. Use the ``qpc source edit`` command to edit a source to accommodate those changes.
 
@@ -771,6 +776,10 @@ Examples
 * Creating a new vcenter source specifying a SSL protocol
 
   ``qpc source add --name vcenter_source --type vcenter --hosts 1.192.0.19 --cred vcenter_cred --ssl-protocol SSLv23``
+
+* Creating a new openShift source using a proxy
+
+  ``qpc source add --name ocp_source --type openshift --hosts api.openshift.example.com --cred ocp_cred --proxy-url http://proxy.example.com:3128``
 
 * Creating a new satellite source disabling SSL
 

--- a/docs/_build/qpc.1
+++ b/docs/_build/qpc.1
@@ -27,7 +27,7 @@ level margin: \\n[rst2man-indent\\n[rst2man-indent-level]]
 .\" new: \\n[rst2man-indent\\n[rst2man-indent-level]]
 .in \\n[rst2man-indent\\n[rst2man-indent-level]]u
 ..
-.TH "qpc" "1" "May 07, 2025" "" "qpc"
+.TH "qpc" "1" "August 04, 2025" "" "qpc"
 .SH NAME
 .sp
 qpc \- Inspect and report on product entitlement metadata from various sources, including networks and systems management solutions.
@@ -282,7 +282,7 @@ When you configure a scan, it contains references to one or more sources, includ
 .sp
 To create a source, supply the type of source with the \fBtype\fP option, one or more host names or IP addresses to connect to with the \fB\-\-hosts\fP option, and the credentials needed to access those systems with the \fB\-\-cred\fP option. The \fBqpc source\fP command allows multiple entries for the \fBhosts\fP and \fBcred\fP options. Therefore, a single source can access a collection of servers and subnets as needed to create an accurate and complete scan.
 .sp
-\fBqpc source add \-\-name=\fP \fIname\fP  \fB\-\-type=\fP \fI(network | vcenter | satellite | openshift | rhacs | ansible)\fP \fB\-\-hosts\fP \fIip_address\fP \fB\-\-cred\fP \fIcredential\fP \fB[\-\-exclude\-hosts\fP \fIip_address\fP \fB]\fP \fB[\-\-port=\fP \fIport\fP \fB]\fP \fB[\-\-use\-paramiko=\fP \fI(True | False)\fP \fB]\fP \fB[\-\-ssl\-cert\-verify=\fP \fI(True | False)\fP \fB]\fP \fB[\-\-ssl\-protocol=\fP \fIprotocol\fP \fB]\fP \fB[\-\-disable\-ssl=\fP \fI(True | False)\fP \fB]\fP
+\fBqpc source add \-\-name=\fP \fIname\fP  \fB\-\-type=\fP \fI(network | vcenter | satellite | openshift | rhacs | ansible)\fP \fB\-\-hosts\fP \fIip_address\fP \fB\-\-cred\fP \fIcredential\fP \fB[\-\-exclude\-hosts\fP \fIip_address\fP \fB]\fP \fB[\-\-port=\fP \fIport\fP \fB]\fP \fB[\-\-use\-paramiko=\fP \fI(True | False)\fP \fB]\fP \fB[\-\-ssl\-cert\-verify=\fP \fI(True | False)\fP \fB]\fP \fB[\-\-ssl\-protocol=\fP \fIprotocol\fP \fB]\fP \fB[\-\-disable\-ssl=\fP \fI(True | False)\fP \fB]\fP \fB[\-\-proxy\-url=\fP \fIproxy url\fP \fB]\fP
 .sp
 \fB\-\-name=name\fP
 .INDENT 0.0
@@ -375,6 +375,14 @@ Optional. Determines the SSL protocol to be used for a secure connection during 
 .INDENT 0.0
 .INDENT 3.5
 Optional. Determines whether SSL communication will be disabled for the scan.
+.UNINDENT
+.UNINDENT
+.sp
+\fB\-\-proxy\-url=url\fP
+.INDENT 0.0
+.INDENT 3.5
+Optional. Sets a proxy server to be used for connecting to the source. This can be helpful in environments that require outbound requests to go through a proxy.
+Use the format protocol://host:port.
 .UNINDENT
 .UNINDENT
 .sp
@@ -952,6 +960,10 @@ Creating a new network source with an excluded host
 Creating a new vcenter source specifying a SSL protocol
 .sp
 \fBqpc source add \-\-name vcenter_source \-\-type vcenter \-\-hosts 1.192.0.19 \-\-cred vcenter_cred \-\-ssl\-protocol SSLv23\fP
+.IP \(bu 2
+Creating a new openShift source using a proxy
+.sp
+\fBqpc source add \-\-name ocp_source \-\-type openshift \-\-hosts api.openshift.example.com \-\-cred ocp_cred \-\-proxy\-url http://proxy.example.com:3128\fP
 .IP \(bu 2
 Creating a new satellite source disabling SSL
 .sp

--- a/docs/source/man-template.rst
+++ b/docs/source/man-template.rst
@@ -232,7 +232,7 @@ Creating and Editing Sources
 
 To create a source, supply the type of source with the ``type`` option, one or more host names or IP addresses to connect to with the ``--hosts`` option, and the credentials needed to access those systems with the ``--cred`` option. The ``QPC_VAR_PROGRAM_NAME source`` command allows multiple entries for the ``hosts`` and ``cred`` options. Therefore, a single source can access a collection of servers and subnets as needed to create an accurate and complete scan.
 
-**QPC_VAR_PROGRAM_NAME source add --name=** *name*  **--type=** *(network | vcenter | satellite | openshift | rhacs | ansible)* **--hosts** *ip_address* **--cred** *credential* **[--exclude-hosts** *ip_address* **]** **[--port=** *port* **]** **[--use-paramiko=** *(True | False)* **]** **[--ssl-cert-verify=** *(True | False)* **]** **[--ssl-protocol=** *protocol* **]** **[--disable-ssl=** *(True | False)* **]**
+**QPC_VAR_PROGRAM_NAME source add --name=** *name*  **--type=** *(network | vcenter | satellite | openshift | rhacs | ansible)* **--hosts** *ip_address* **--cred** *credential* **[--exclude-hosts** *ip_address* **]** **[--port=** *port* **]** **[--use-paramiko=** *(True | False)* **]** **[--ssl-cert-verify=** *(True | False)* **]** **[--ssl-protocol=** *protocol* **]** **[--disable-ssl=** *(True | False)* **]** **[--proxy-url=** *proxy url* **]**
 
 ``--name=name``
 
@@ -295,6 +295,11 @@ To create a source, supply the type of source with the ``type`` option, one or m
 ``--disable-ssl=(True | False)``
 
   Optional. Determines whether SSL communication will be disabled for the scan.
+
+``--proxy-url=url``
+
+  Optional. Sets a proxy server to be used for connecting to the source. This can be helpful in environments that require outbound requests to go through a proxy.
+  Use the format protocol://host:port.
 
 The information in a source might change as the structure of the network changes. Use the ``QPC_VAR_PROGRAM_NAME source edit`` command to edit a source to accommodate those changes.
 
@@ -771,6 +776,10 @@ Examples
 * Creating a new vcenter source specifying a SSL protocol
 
   ``QPC_VAR_PROGRAM_NAME source add --name vcenter_source --type vcenter --hosts 1.192.0.19 --cred vcenter_cred --ssl-protocol SSLv23``
+
+* Creating a new openShift source using a proxy
+
+  ``QPC_VAR_PROGRAM_NAME source add --name ocp_source --type openshift --hosts api.openshift.example.com --cred ocp_cred --proxy-url http://proxy.example.com:3128``
 
 * Creating a new satellite source disabling SSL
 

--- a/qpc/messages.py
+++ b/qpc/messages.py
@@ -139,6 +139,9 @@ SOURCE_LIST_NO_SOURCES = "No sources exist yet."
 SOURCE_TYPE_FILTER_HELP = (
     "Filter for listing sources by type. Valid values: vcenter, network."
 )
+SOURCE_PROXY_URL_HELP = (
+    "Optional proxy to use for this source in the format http(s)://host:port"
+)
 
 
 SCAN_NAME_HELP = "Scan name."

--- a/qpc/source/add.py
+++ b/qpc/source/add.py
@@ -117,6 +117,13 @@ class SourceAddCommand(CliCommand):
             help=_(messages.SOURCE_PARAMIKO_HELP),
             required=False,
         )
+        self.parser.add_argument(
+            "--proxy-url",
+            dest="proxy_url",
+            metavar="PROXY_URL",
+            help=_(messages.SOURCE_PROXY_URL_HELP),
+            required=False,
+        )
 
     def _validate_args(self):
         CliCommand._validate_args(self)

--- a/qpc/source/edit.py
+++ b/qpc/source/edit.py
@@ -107,6 +107,13 @@ class SourceEditCommand(CliCommand):
             help=_(messages.SOURCE_PARAMIKO_HELP),
             required=False,
         )
+        self.parser.add_argument(
+            "--proxy-url",
+            dest="proxy_url",
+            metavar="PROXY_URL",
+            help=_(messages.SOURCE_PROXY_URL_HELP),
+            required=False,
+        )
 
     def _validate_args(self):  # noqa: C901 PLR0912
         CliCommand._validate_args(self)
@@ -120,6 +127,7 @@ class SourceEditCommand(CliCommand):
             or self.args.ssl_cert_verify
             or self.args.disable_ssl
             or self.args.ssl_protocol
+            or self.args.proxy_url
         ):
             logger.error(_(messages.SOURCE_EDIT_NO_ARGS), (self.args.name))
             self.parser.print_help()

--- a/qpc/source/utils.py
+++ b/qpc/source/utils.py
@@ -67,5 +67,9 @@ def build_source_payload(args, add_none=True):  # noqa: C901 PLR0912
         req_payload["ssl_protocol"] = args.ssl_protocol
     if hasattr(args, "use_paramiko") and args.use_paramiko is not None:
         req_payload["use_paramiko"] = args.use_paramiko
+    if hasattr(args, "proxy_url") and args.proxy_url:
+        req_payload["proxy_url"] = args.proxy_url
+    elif add_none:
+        req_payload["proxy_url"] = None
 
     return req_payload

--- a/qpc/tests/source/test_source_utils.py
+++ b/qpc/tests/source/test_source_utils.py
@@ -34,6 +34,7 @@ class TestBuildSourcePayloadV2:
             "hosts": ["host1"],
             "credentials": [1],
             "port": None,
+            "proxy_url": None,
         }
 
     def test_add_none_false_omits_missing_fields(self):
@@ -67,6 +68,7 @@ class TestBuildSourcePayloadV2:
             "disable_ssl": False,
             "ssl_protocol": "TLSv1_1",
             "use_paramiko": "true",
+            "proxy_url": None,
         }
 
     @pytest.mark.parametrize(


### PR DESCRIPTION
This PR adds support for the proxy_url field in the Add/Edit Source for all non-network sources. It relies on backend proxy validation. 

Relates to JIRA: DISCOVERY-433

## Summary by Sourcery

Add support for specifying and handling a proxy_url in the source add and edit CLI commands, including payload construction and validation via backend.

New Features:
- Add optional --proxy-url argument to source add and edit commands
- Include proxy_url field in the source payload sent to the API

Enhancements:
- Default proxy_url to null when not provided
- Update source tests to cover valid and invalid proxy_url scenarios