### PR TITLE
refactor(source): switch bulk delete to use v2

### DIFF
--- a/qpc/source/__init__.py
+++ b/qpc/source/__init__.py
@@ -15,7 +15,7 @@ VCENTER_SOURCE_TYPE = "vcenter"
 RHACS_SOURCE_TYPE = "rhacs"
 
 SOURCE_URI = "/api/v2/sources/"
-SOURCE_BULK_DELETE_URI = "/api/v1/sources/bulk_delete/"
+SOURCE_BULK_DELETE_URI = "/api/v2/sources/bulk_delete/"
 SOURCE_TYPE_CHOICES = [
     ANSIBLE_SOURCE_TYPE,
     NETWORK_SOURCE_TYPE,


### PR DESCRIPTION
 Replaces usage of the v1 bulk delete API with the v2 version to align
 with updated backend functionality. No UI behavior changes expected.

 Relates to JIRA: DISCOVERY-1006