### PR TITLE
feat: add "--summary" optional argument to "scan list" command for simplified table output

### DIFF
--- a/qpc/scan/list.py
+++ b/qpc/scan/list.py
@@ -14,6 +14,65 @@ from qpc.utils import pretty_format
 logger = getLogger(__name__)
 
 
+def actually_pretty_format(json_data: list[dict]) -> str:
+    """
+    Format json_data (list of Scan responses) to an even prettier format.
+
+    This outputs an ASCII art like table containing only specific fields,
+    and it pads columns dynamically to fit variable width fields in json_data.
+
+    Example output:
+
+       scan_id | scan_name                                | report_id | status
+      ---------+------------------------------------------+-----------+-----------
+       5       | 1753469322-shrocp4upi417ovn              | 3         | completed
+       6       | 1753469427-shrocp4upi417ovn (django-5.2) | 4         | completed
+       10      | asdasd                                   | None      | failed
+       9       | aws-20250829-a                           | 7         | completed
+       8       | dev01-2025-08-28-1328                    | 6         | completed
+       7       | net-20250825150855                       | 5         | completed
+       1       | scan-1                                   | 1         | completed
+       2       | scan-2                                   | 2         | completed
+
+    This function is purpose-made for formatting lists of Scan responses and
+    is not suitable for formatting other API responses in its current form.
+    """
+    minimal_data = []
+    for item in json_data:
+        relevant = dict()
+        relevant["scan_id"] = str(item["id"])
+        relevant["scan_name"] = str(item["name"])
+        relevant["report_id"] = str(item.get("most_recent", {}).get("report_id", None))
+        relevant["status"] = str(item.get("most_recent", {}).get("status", None))
+        minimal_data.append(relevant)
+
+    if not minimal_data:
+        return _("No scans found.")
+
+    column_widths = {}
+    for key in minimal_data[0].keys():
+        column_widths[key] = len(key)
+    for item in minimal_data:
+        for key, value in item.items():
+            column_widths[key] = max(column_widths[key], len(str(value)))
+
+    output = (
+        "|".join((f" {key.ljust(value)} " for key, value in column_widths.items()))
+        + "\n"
+    )
+    output += (
+        "+".join(("-" * (value + 2) for key, value in column_widths.items())) + "\n"
+    )
+    for item in minimal_data:
+        output += (
+            "|".join(
+                (f" {item[key].ljust(value)} " for key, value in column_widths.items())
+            )
+            + "\n"
+        )
+    return output
+
+
 class ScanListCommand(CliCommand):
     """Defines the list command.
 
@@ -33,6 +92,12 @@ class ScanListCommand(CliCommand):
             GET,
             scan.SCAN_URI,
             [codes.ok],
+        )
+        self.parser.add_argument(
+            "--summary",
+            dest="output_summary",
+            action="store_true",
+            help=_("Output results in simplified summary table"),  # TODO FIXME
         )
         self.parser.add_argument(
             "--type",
@@ -55,6 +120,9 @@ class ScanListCommand(CliCommand):
         results = json_data.get("results", [])
         if count == 0:
             logger.error(_(messages.SCAN_LIST_NO_SCANS))
+        elif getattr(self.args, "output_summary", False):
+            data = actually_pretty_format(results)
+            print(data)
         else:
             data = pretty_format(results)
             print(data)


### PR DESCRIPTION
Not ready to merge. Very prototype-quality code. Needs testing.

Example output:

```
$ qpc scan list --summary
 scan_id | scan_name                                | report_id | status
---------+------------------------------------------+-----------+-----------
 5       | 1753469322-shrocp4upi417ovn              | 3         | completed
 6       | 1753469427-shrocp4upi417ovn (django-5.2) | 4         | completed
 9       | aws-20250829-a                           | 7         | completed
 8       | dev01-2025-08-28-1328                    | 6         | completed
 7       | net-20250825150855                       | 5         | completed
 1       | scan-1                                   | 1         | completed
 2       | scan-2                                   | 2         | completed
```

## Summary by Sourcery

Add a "--summary" flag to the "scan list" command to print a simplified table of scan results using a new prototype formatter

New Features:
- Support for an optional "--summary" argument on the "scan list" command
- Introduce a prototype "actually_pretty_format" function for aligned table output

Enhancements:
- Integrate the summary formatter into the command response handling

Chores:
- Include placeholder help text and TODO comments for future improvements