### PR TITLE
feat: add --table option argument to scan list command

### DIFF
--- a/qpc/scan/list.py
+++ b/qpc/scan/list.py
@@ -9,7 +9,7 @@ from qpc import messages, scan
 from qpc.clicommand import CliCommand
 from qpc.request import GET
 from qpc.translation import _
-from qpc.utils import pretty_format
+from qpc.utils import pretty_format, tabular_format
 
 logger = getLogger(__name__)
 
@@ -35,6 +35,12 @@ class ScanListCommand(CliCommand):
             [codes.ok],
         )
         self.parser.add_argument(
+            "--table",
+            dest="output_table",
+            action="store_true",
+            help="Provide tabular formatting of output data (human-readable format).",
+        )
+        self.parser.add_argument(
             "--type",
             dest="type",
             choices=[scan.SCAN_TYPE_CONNECT, scan.SCAN_TYPE_INSPECT],
@@ -55,6 +61,15 @@ class ScanListCommand(CliCommand):
         results = json_data.get("results", [])
         if count == 0:
             logger.error(_(messages.SCAN_LIST_NO_SCANS))
+        elif self.args.output_table:
+            fields = {
+                "scan_id": "id",
+                "scan_name": "name",
+                "report_id": "most_recent.report_id",
+                "status": "most_recent.status",
+            }
+            table = tabular_format(results, fields)
+            print(table)
         else:
             data = pretty_format(results)
             print(data)

--- a/qpc/tests/scan/test_scan_list.py
+++ b/qpc/tests/scan/test_scan_list.py
@@ -108,6 +108,7 @@ class TestScanListCli:
             mocker.get(next_link, status_code=200, json=data2)
 
             args = Namespace()
+            args.output_table = False
             with redirect_stdout(scan_out):
                 self.command.main(args)
                 expected = (
@@ -133,6 +134,7 @@ class TestScanListCli:
             mocker.get(url, status_code=200, json=data)
 
             args = Namespace(type="inspect")
+            args.output_table = False
             with redirect_stdout(scan_out):
                 self.command.main(args)
                 expected = (

--- a/qpc/tests/test_qpc_utils.py
+++ b/qpc/tests/test_qpc_utils.py
@@ -33,3 +33,38 @@ class TestUtils:
         fileobj = utils.create_tar_buffer(test_file)
         json = utils.extract_json_from_tar(fileobj, print_pretty=False)
         assert json == report_json
+
+    def test_tabular_format(self):
+        """Test tabular output from json_data."""
+        json_data = []
+        output = utils.tabular_format(json_data, {})
+        assert output == "No data to display."
+        json_data = [
+            {
+                "id": "1",
+                "name": "scan1",
+                "most_recent": {"report_id": "1", "status": "completed"},
+            },
+            {
+                "id": "2",
+                "name": "scan1",
+                "most_recent": {"report_id": "2", "status": "completed"},
+            },
+            {"id": "3", "name": "scan3"},
+        ]
+        fields = {
+            "scan_id": "id",
+            "scan_name": "name",
+            "report_id": "most_recent.report_id",
+            "status": "most_recent.status",
+        }
+        output = utils.tabular_format(json_data, fields)
+        output = output.split("\n")
+        # Test table headers
+        for field in fields.keys():
+            assert field in output[0]
+        # Test the presence of data in rows
+        for index, data in enumerate(json_data):
+            for path in fields.values():
+                value = utils.json_data_deep_get(data, path)
+                assert str(value) in output[index + 2]

--- a/qpc/tests/test_utils.py
+++ b/qpc/tests/test_utils.py
@@ -3,7 +3,7 @@
 import pytest
 
 from qpc.messages import PROMPT_INPUT
-from qpc.utils import check_if_prompt_is_not_empty
+from qpc.utils import check_if_prompt_is_not_empty, json_data_deep_get
 
 
 @pytest.mark.parametrize("pass_prompt", ["", None])
@@ -13,3 +13,19 @@ def test_invalid_pass_prompt(pass_prompt, caplog):
     with pytest.raises(SystemExit):
         check_if_prompt_is_not_empty(pass_prompt)
     assert caplog.messages[-1] == PROMPT_INPUT
+
+
+@pytest.mark.parametrize(
+    "json_data, key_path, expected_result",
+    [
+        ({"k1": "v1", "k2": "v2"}, "", None),
+        ({"k1": "v1", "k2": "v2"}, "k2", "v2"),
+        ({"k1": "v1", "k2": "v2"}, "missing", None),
+        ({"l1": {"l2": {"l3": "v3"}}}, "l1.l2.l3", "v3"),
+        ({"l1": {"l2": {"l3": "v3"}}}, "l1.missing.l3", None),
+    ],
+)
+def test_json_data_deep_get(json_data, key_path, expected_result):
+    """Test json_data_deep_get function."""
+    result = json_data_deep_get(json_data, key_path)
+    assert result == expected_result

--- a/qpc/utils.py
+++ b/qpc/utils.py
@@ -400,6 +400,63 @@ def pretty_format(json_data):
     return json.dumps(json_data, sort_keys=True, indent=4, separators=(",", ": "))
 
 
+def tabular_format(json_data: list[dict], fields: dict) -> str:
+    """Provide tabular formatting of output json data.
+
+    :param json_data: the json data to tabular print
+    :param fields: the fields (name:path) to include in the tabular print
+    :returns: the tabular print string of the json data
+    """
+    rows = []
+    for row in json_data:
+        data = {
+            key: str(json_data_deep_get(row, value)) for key, value in fields.items()
+        }
+        rows.append(data)
+    if not rows:
+        return t("No data to display.")
+    column_widths = {key: len(key) for key in rows[0].keys()}
+    for row in rows:
+        for key, value in row.items():
+            column_widths[key] = max(column_widths[key], len(str(value)))
+    output = (
+        "|".join((f" {key.ljust(value)} " for key, value in column_widths.items()))
+        + "\n"
+    )
+    output += (
+        "+".join(("-" * (value + 2) for key, value in column_widths.items())) + "\n"
+    )
+    for row in rows:
+        output += (
+            "|".join(
+                (f" {row[key].ljust(value)} " for key, value in column_widths.items())
+            )
+            + "\n"
+        )
+    return output
+
+
+def json_data_deep_get(json_data: dict, key_path: str = "", default=None):
+    """Get data from json_data based on key path.
+
+    :param json_data: the json_data to get data from
+    :param key_path: the key path to get data from.
+    It is a string of keys separated by dots.
+    :param default: the default value to return if the key path is not found
+    :returns: the data from the json_data based on the key path
+    """
+    if not key_path:
+        return default
+    key_path = key_path.split(".")
+    data = json_data
+    for key in key_path:
+        if isinstance(data, dict) and key in data:
+            data = data[key]
+        else:
+            return default
+    return data
+
+
 # Read in a file and make it a list
 def read_in_file(filename):
     """Read values from file into a list object. Expecting newline delimited.


### PR DESCRIPTION
Add a "--table" option to the "scan list" command to print a simplified table of scan results (human-readable output).

Example:
```
$ qpc scan list --table
 scan_id | scan_name           | report_id | status    
---------+---------------------+-----------+-----------
 3       | xyz                 | None      | None      
 2       | my-new-scan-with-mw | 2         | completed 
 1       | my-scan             | 1         | completed 
```

Relates to JIRA: DISCOVERY-1084

## Summary by Sourcery

Add a "--table" option to the scan list command for human-readable table output, leveraging a new tabular_format utility to render JSON lists as tables and updating tests accordingly.

New Features:
- Add --table flag to scan list command to enable tabular output of scan results.

Enhancements:
- Introduce tabular_format and _json_data_deep_get utilities for rendering JSON data in table form.

Tests:
- Update scan list tests to include output_table flag in test arguments.