### PR TITLE
refactor: bump QPC_MIN_SERVER_VERSION to 2.5.0

### DIFF
--- a/qpc/clicommand.py
+++ b/qpc/clicommand.py
@@ -25,8 +25,7 @@ class CliCommand:
         self.req_headers = None
         self.response = None
 
-        # If you add or change API, you must update these versions
-        # this includes self.min_server_version
+        # Minimum server version required by the CLI
         self.min_server_version = QPC_MIN_SERVER_VERSION
 
     def _validate_args(self):

--- a/qpc/report/deployments.py
+++ b/qpc/report/deployments.py
@@ -74,7 +74,6 @@ class ReportDeploymentsCommand(CliCommand):
             help=_(messages.REPORT_PATH_HELP),
         )
         self.report_id = None
-        self.min_server_version = "0.9.2"
 
     def _validate_args(self):  # noqa: PLR0912
         CliCommand._validate_args(self)

--- a/qpc/report/details.py
+++ b/qpc/report/details.py
@@ -74,7 +74,6 @@ class ReportDetailsCommand(CliCommand):
             help=_(messages.REPORT_PATH_HELP),
         )
         self.report_id = None
-        self.min_server_version = "0.9.2"
 
     def _validate_args(self):  # noqa: PLR0912
         CliCommand._validate_args(self)

--- a/qpc/report/download.py
+++ b/qpc/report/download.py
@@ -54,7 +54,6 @@ class ReportDownloadCommand(CliCommand):
             help=_(messages.DOWNLOAD_PATH_HELP),
             required=True,
         )
-        self.min_server_version = "0.9.2"
         self.report_id = None
 
     def _validate_args(self):

--- a/qpc/report/insights.py
+++ b/qpc/report/insights.py
@@ -55,8 +55,6 @@ class ReportInsightsCommand(CliCommand):
             metavar="PATH",
             help=_(messages.REPORT_PATH_HELP),
         )
-        # Don't change this when you upgrade versions
-        self.min_server_version = "0.9.0"
         self.report_id = None
 
     def _insights_report_available(self, sources):

--- a/qpc/tests/report/test_report_deployments.py
+++ b/qpc/tests/report/test_report_deployments.py
@@ -14,12 +14,11 @@ import requests_mock
 
 from qpc import messages
 from qpc.cli import CLI
-from qpc.release import VERSION
 from qpc.report import REPORT_URI
 from qpc.report.deployments import ReportDeploymentsCommand
 from qpc.scan import SCAN_JOB_URI
 from qpc.tests.utilities import redirect_stdout
-from qpc.utils import create_tar_buffer, get_server_location
+from qpc.utils import QPC_MIN_SERVER_VERSION, create_tar_buffer, get_server_location
 
 
 @pytest.fixture
@@ -66,7 +65,7 @@ class TestReportDeployments:
                 get_report_url,
                 status_code=200,
                 content=buffer_content,
-                headers={"X-Server-Version": VERSION},
+                headers={"X-Server-Version": QPC_MIN_SERVER_VERSION},
             )
 
             args = Namespace(
@@ -95,7 +94,7 @@ class TestReportDeployments:
                 get_report_url,
                 status_code=200,
                 content=buffer_content,
-                headers={"X-Server-Version": VERSION},
+                headers={"X-Server-Version": QPC_MIN_SERVER_VERSION},
             )
 
             args = Namespace(
@@ -126,7 +125,7 @@ class TestReportDeployments:
                 get_report_url,
                 status_code=200,
                 content=get_report_response.encode("utf-8"),
-                headers={"X-Server-Version": VERSION},
+                headers={"X-Server-Version": QPC_MIN_SERVER_VERSION},
             )
 
             args = Namespace(
@@ -241,7 +240,7 @@ class TestReportDeployments:
                 get_report_url,
                 status_code=200,
                 content=buffer_content,
-                headers={"X-Server-Version": VERSION},
+                headers={"X-Server-Version": QPC_MIN_SERVER_VERSION},
             )
 
             args = Namespace(
@@ -342,7 +341,7 @@ class TestReportDeployments:
                 get_report_url,
                 status_code=400,
                 content=buffer_content,
-                headers={"X-Server-Version": VERSION},
+                headers={"X-Server-Version": QPC_MIN_SERVER_VERSION},
             )
 
             args = Namespace(
@@ -372,7 +371,7 @@ class TestReportDeployments:
                 get_report_url,
                 status_code=400,
                 content=buffer_content,
-                headers={"X-Server-Version": VERSION},
+                headers={"X-Server-Version": QPC_MIN_SERVER_VERSION},
             )
 
             args = Namespace(
@@ -429,7 +428,7 @@ def test_deployments_report_as_json_no_output_file(caplog, capsys, requests_mock
         report_url,
         status_code=200,
         content=buffer_content,
-        headers={"X-Server-Version": VERSION},
+        headers={"X-Server-Version": QPC_MIN_SERVER_VERSION},
     )
     sys.argv = [
         "/bin/qpc",

--- a/qpc/tests/report/test_report_deployments.py
+++ b/qpc/tests/report/test_report_deployments.py
@@ -410,7 +410,7 @@ class TestReportDeployments:
                 with pytest.raises(SystemExit):
                     self.command.main(args)
                 err_msg = messages.SERVER_TOO_OLD_FOR_CLI % {
-                    "min_version": "0.9.2",
+                    "min_version": QPC_MIN_SERVER_VERSION,
                     "current_version": "0.0.45",
                 }
                 assert err_msg in caplog.text

--- a/qpc/tests/report/test_report_details.py
+++ b/qpc/tests/report/test_report_details.py
@@ -398,7 +398,7 @@ class TestReportDetails:
                 with pytest.raises(SystemExit):
                     self.command.main(args)
                 err_msg = messages.SERVER_TOO_OLD_FOR_CLI % {
-                    "min_version": "0.9.2",
+                    "min_version": QPC_MIN_SERVER_VERSION,
                     "current_version": "0.0.45",
                 }
                 assert err_msg in caplog.text

--- a/qpc/tests/report/test_report_details.py
+++ b/qpc/tests/report/test_report_details.py
@@ -14,12 +14,11 @@ import requests_mock
 
 from qpc import messages
 from qpc.cli import CLI
-from qpc.release import VERSION
 from qpc.report import REPORT_URI
 from qpc.report.details import ReportDetailsCommand
 from qpc.scan import SCAN_JOB_URI
 from qpc.tests.utilities import redirect_stdout
-from qpc.utils import create_tar_buffer, get_server_location
+from qpc.utils import QPC_MIN_SERVER_VERSION, create_tar_buffer, get_server_location
 
 
 @pytest.fixture
@@ -66,7 +65,7 @@ class TestReportDetails:
                 get_report_url,
                 status_code=200,
                 content=buffer_content,
-                headers={"X-Server-Version": VERSION},
+                headers={"X-Server-Version": QPC_MIN_SERVER_VERSION},
             )
 
             args = Namespace(
@@ -95,7 +94,7 @@ class TestReportDetails:
                 get_report_url,
                 status_code=200,
                 content=buffer_content,
-                headers={"X-Server-Version": VERSION},
+                headers={"X-Server-Version": QPC_MIN_SERVER_VERSION},
             )
 
             args = Namespace(
@@ -130,7 +129,7 @@ class TestReportDetails:
                 get_report_url,
                 status_code=200,
                 json=get_report_csv_data,
-                headers={"X-Server-Version": VERSION},
+                headers={"X-Server-Version": QPC_MIN_SERVER_VERSION},
             )
 
             args = Namespace(
@@ -231,7 +230,7 @@ class TestReportDetails:
                 get_report_url,
                 status_code=200,
                 content=buffer_content,
-                headers={"X-Server-Version": VERSION},
+                headers={"X-Server-Version": QPC_MIN_SERVER_VERSION},
             )
 
             args = Namespace(
@@ -330,7 +329,7 @@ class TestReportDetails:
                 get_report_url,
                 status_code=400,
                 json=get_report_json_data,
-                headers={"X-Server-Version": VERSION},
+                headers={"X-Server-Version": QPC_MIN_SERVER_VERSION},
             )
 
             args = Namespace(
@@ -360,7 +359,7 @@ class TestReportDetails:
                 get_report_url,
                 status_code=400,
                 content=buffer_content,
-                headers={"X-Server-Version": VERSION},
+                headers={"X-Server-Version": QPC_MIN_SERVER_VERSION},
             )
 
             args = Namespace(
@@ -417,7 +416,7 @@ def test_details_report_as_json_no_output_file(caplog, capsys, requests_mock):
         report_url,
         status_code=200,
         content=buffer_content,
-        headers={"X-Server-Version": VERSION},
+        headers={"X-Server-Version": QPC_MIN_SERVER_VERSION},
     )
     sys.argv = [
         "/bin/qpc",

--- a/qpc/tests/report/test_report_download.py
+++ b/qpc/tests/report/test_report_download.py
@@ -233,7 +233,7 @@ class TestReportDownload:
                 with pytest.raises(SystemExit):
                     self.command.main(args)
                 err_msg = messages.SERVER_TOO_OLD_FOR_CLI % {
-                    "min_version": "0.9.2",
+                    "min_version": QPC_MIN_SERVER_VERSION,
                     "current_version": "0.0.45",
                 }
                 assert err_msg in caplog.text

--- a/qpc/tests/report/test_report_download.py
+++ b/qpc/tests/report/test_report_download.py
@@ -11,11 +11,10 @@ import requests_mock
 
 from qpc import messages
 from qpc.cli import CLI
-from qpc.release import VERSION
 from qpc.report import REPORT_URI
 from qpc.report.download import ReportDownloadCommand
 from qpc.scan import SCAN_JOB_URI
-from qpc.utils import create_tar_buffer, get_server_location
+from qpc.utils import QPC_MIN_SERVER_VERSION, create_tar_buffer, get_server_location
 
 
 @pytest.fixture
@@ -56,7 +55,7 @@ class TestReportDownload:
             mocker.get(
                 get_report_url,
                 status_code=200,
-                headers={"X-Server-Version": VERSION},
+                headers={"X-Server-Version": QPC_MIN_SERVER_VERSION},
                 content=buffer_content,
             )
 
@@ -79,7 +78,7 @@ class TestReportDownload:
             mocker.get(
                 get_report_url,
                 status_code=200,
-                headers={"X-Server-Version": VERSION},
+                headers={"X-Server-Version": QPC_MIN_SERVER_VERSION},
                 content=buffer_content,
             )
 
@@ -184,7 +183,7 @@ class TestReportDownload:
             mocker.get(
                 get_report_url,
                 status_code=200,
-                headers={"X-Server-Version": VERSION},
+                headers={"X-Server-Version": QPC_MIN_SERVER_VERSION},
                 content=buffer_content,
             )
 
@@ -206,7 +205,7 @@ class TestReportDownload:
             mocker.get(
                 get_report_url,
                 status_code=400,
-                headers={"X-Server-Version": VERSION},
+                headers={"X-Server-Version": QPC_MIN_SERVER_VERSION},
                 json=get_report_json_data,
             )
 
@@ -249,7 +248,7 @@ class TestReportDownload:
             mocker.get(
                 get_report_url,
                 status_code=200,
-                headers={"X-Server-Version": VERSION},
+                headers={"X-Server-Version": QPC_MIN_SERVER_VERSION},
                 content=buffer_content,
             )
 

--- a/qpc/tests/report/test_report_insights.py
+++ b/qpc/tests/report/test_report_insights.py
@@ -14,12 +14,11 @@ import requests_mock
 
 from qpc import messages
 from qpc.cli import CLI
-from qpc.release import VERSION
 from qpc.report import REPORT_URI
 from qpc.report.insights import ReportInsightsCommand
 from qpc.scan import SCAN_JOB_URI
 from qpc.tests.utilities import redirect_stdout
-from qpc.utils import create_tar_buffer, get_server_location
+from qpc.utils import QPC_MIN_SERVER_VERSION, create_tar_buffer, get_server_location
 
 
 @pytest.fixture
@@ -67,7 +66,7 @@ class TestReportInsights:
             mocker.get(
                 get_report_url,
                 status_code=200,
-                headers={"X-Server-Version": VERSION},
+                headers={"X-Server-Version": QPC_MIN_SERVER_VERSION},
                 content=buffer_content,
             )
 
@@ -92,13 +91,13 @@ class TestReportInsights:
             mocker.get(
                 scanjob_report_url,
                 status_code=200,
-                headers={"X-Server-Version": VERSION},
+                headers={"X-Server-Version": QPC_MIN_SERVER_VERSION},
                 json=scanjob_data,
             )
             mocker.get(
                 get_report_url,
                 status_code=200,
-                headers={"X-Server-Version": VERSION},
+                headers={"X-Server-Version": QPC_MIN_SERVER_VERSION},
                 content=buffer_content,
             )
 
@@ -173,13 +172,13 @@ class TestReportInsights:
             mocker.get(
                 scanjob_report_url,
                 status_code=200,
-                headers={"X-Server-Version": VERSION},
+                headers={"X-Server-Version": QPC_MIN_SERVER_VERSION},
                 json=scanjob_data,
             )
             mocker.get(
                 get_report_url,
                 status_code=200,
-                headers={"X-Server-Version": VERSION},
+                headers={"X-Server-Version": QPC_MIN_SERVER_VERSION},
                 content=buffer_content,
             )
 
@@ -223,7 +222,7 @@ class TestReportInsights:
             mocker.get(
                 get_report_url,
                 status_code=200,
-                headers={"X-Server-Version": VERSION},
+                headers={"X-Server-Version": QPC_MIN_SERVER_VERSION},
                 content=buffer_content,
             )
 
@@ -245,12 +244,12 @@ class TestReportInsights:
             mocker.get(
                 scanjob_report_url,
                 status_code=404,
-                headers={"X-Server-Version": VERSION},
+                headers={"X-Server-Version": QPC_MIN_SERVER_VERSION},
             )
             mocker.get(
                 get_report_url,
                 status_code=400,
-                headers={"X-Server-Version": VERSION},
+                headers={"X-Server-Version": QPC_MIN_SERVER_VERSION},
                 content=buffer_content,
             )
 
@@ -274,7 +273,7 @@ class TestReportInsights:
             mocker.get(
                 get_report_url,
                 status_code=400,
-                headers={"X-Server-Version": VERSION},
+                headers={"X-Server-Version": QPC_MIN_SERVER_VERSION},
                 content=buffer_content,
             )
 
@@ -295,7 +294,7 @@ def test_insights_report_as_json_no_output_file(caplog, capsys, requests_mock):
         scanjob_report_url,
         status_code=200,
         json=scanjob_data,
-        headers={"X-Server-Version": VERSION},
+        headers={"X-Server-Version": QPC_MIN_SERVER_VERSION},
     )
     report_url = get_server_location() + REPORT_URI + "1/insights/"
     report_json_data = {
@@ -309,7 +308,7 @@ def test_insights_report_as_json_no_output_file(caplog, capsys, requests_mock):
         report_url,
         status_code=200,
         json=expected_json,
-        headers={"X-Server-Version": VERSION},
+        headers={"X-Server-Version": QPC_MIN_SERVER_VERSION},
     )
     sys.argv = [
         "/bin/qpc",
@@ -370,7 +369,7 @@ def test_insights_not_available_report_id(caplog, capsys, requests_mock):
         scanjob_report_url,
         status_code=200,
         json=scanjob_data,
-        headers={"X-Server-Version": VERSION},
+        headers={"X-Server-Version": QPC_MIN_SERVER_VERSION},
     )
     sys.argv = [
         "/bin/qpc",
@@ -414,7 +413,7 @@ def test_insights_mix_sources_scan_job(caplog, capsys, requests_mock):
         report_url,
         status_code=200,
         json=expected_json,
-        headers={"X-Server-Version": VERSION},
+        headers={"X-Server-Version": QPC_MIN_SERVER_VERSION},
     )
     sys.argv = [
         "/bin/qpc",
@@ -447,7 +446,7 @@ def test_insights_mix_sources_report_id(caplog, capsys, requests_mock):
         scanjob_report_url,
         status_code=200,
         json=scanjob_data,
-        headers={"X-Server-Version": VERSION},
+        headers={"X-Server-Version": QPC_MIN_SERVER_VERSION},
     )
     report_url = get_server_location() + REPORT_URI + "1/insights/"
     report_json_data = {
@@ -461,7 +460,7 @@ def test_insights_mix_sources_report_id(caplog, capsys, requests_mock):
         report_url,
         status_code=200,
         json=expected_json,
-        headers={"X-Server-Version": VERSION},
+        headers={"X-Server-Version": QPC_MIN_SERVER_VERSION},
     )
     sys.argv = [
         "/bin/qpc",

--- a/qpc/tests/report/test_report_list.py
+++ b/qpc/tests/report/test_report_list.py
@@ -9,11 +9,10 @@ import pytest
 import requests_mock
 
 from qpc.cli import CLI
-from qpc.release import VERSION
 from qpc.report import REPORT_V2_URI
 from qpc.report.list import ReportListCommand
 from qpc.tests.utilities import redirect_stdout
-from qpc.utils import get_server_location
+from qpc.utils import QPC_MIN_SERVER_VERSION, get_server_location
 
 
 @pytest.fixture
@@ -58,7 +57,7 @@ class TestReportListCommand:
                 get_report_url,
                 status_code=200,
                 json=report_json_data,
-                headers={"X-Server-Version": VERSION},
+                headers={"X-Server-Version": QPC_MIN_SERVER_VERSION},
             )
 
             args = Namespace()
@@ -79,7 +78,7 @@ def test_list_report_as_json(
         get_report_url,
         status_code=200,
         json=report_json_data,
-        headers={"X-Server-Version": VERSION},
+        headers={"X-Server-Version": QPC_MIN_SERVER_VERSION},
     )
     sys.argv = [
         "/bin/qpc",

--- a/qpc/tests/report/test_report_show.py
+++ b/qpc/tests/report/test_report_show.py
@@ -11,11 +11,10 @@ import requests_mock
 
 from qpc import messages
 from qpc.cli import CLI
-from qpc.release import VERSION
 from qpc.report import REPORT_V2_URI
 from qpc.report.show import ReportShowCommand
 from qpc.tests.utilities import redirect_stdout
-from qpc.utils import get_server_location
+from qpc.utils import QPC_MIN_SERVER_VERSION, get_server_location
 
 
 @pytest.fixture
@@ -51,7 +50,7 @@ class TestReportShowCommand:
                 get_report1_url,
                 status_code=200,
                 json=report1_json_data,
-                headers={"X-Server-Version": VERSION},
+                headers={"X-Server-Version": QPC_MIN_SERVER_VERSION},
             )
 
             args = Namespace(
@@ -71,7 +70,7 @@ class TestReportShowCommand:
                 get_report1_url,
                 status_code=400,
                 json=report1_json_data,
-                headers={"X-Server-Version": VERSION},
+                headers={"X-Server-Version": QPC_MIN_SERVER_VERSION},
             )
 
             args = Namespace(
@@ -93,7 +92,7 @@ def test_show_report_as_json(
         get_report1_url,
         status_code=200,
         json=report1_json_data,
-        headers={"X-Server-Version": VERSION},
+        headers={"X-Server-Version": QPC_MIN_SERVER_VERSION},
     )
     sys.argv = [
         "/bin/qpc",

--- a/qpc/utils.py
+++ b/qpc/utils.py
@@ -54,7 +54,7 @@ DEFAULT_INSIGHTS_CONFIG = {
 
 LOG_LEVEL_INFO = 0
 
-QPC_MIN_SERVER_VERSION = "2.4.0"
+QPC_MIN_SERVER_VERSION = "2.5.0"
 
 logging.captureWarnings(True)
 logger = logging.getLogger(__name__)


### PR DESCRIPTION
Remove per-subcommand min_server_version overrides from report deployments, details, download, and insights commands. Mixing old and new server/client is not supported, so all commands should use the single global QPC_MIN_SERVER_VERSION. Bump it from 2.4.0 to 2.5.0 to reflect the new APIs required by report show and list.

Relates to JIRA: DISCOVERY-1272

## Summary by Sourcery

Align CLI minimum server version requirements with a single global value and update it to 2.5.0.

Enhancements:
- Centralize min server version validation on the global QPC_MIN_SERVER_VERSION constant instead of per-report subcommand overrides.
- Update the global CLI minimum supported server version from 2.4.0 to 2.5.0 to reflect new server API requirements.