### PR TITLE
build: update qpc to version 2.5.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "qpc"
-version = "2.4.3"
+version = "2.5.0"
 description = "The command-line client for quipucords servers"
 authors = [{ name = "QPC Team", email = "quipucords@redhat.com" }]
 requires-python = ">=3.12,<3.14"

--- a/qpc.spec
+++ b/qpc.spec
@@ -15,7 +15,7 @@
 Name:           qpc
 Summary:        command-line client interface for quipucords
 
-Version:        2.4.3
+Version:        2.5.0
 Release:        1%{?dist}
 Epoch:          0
 

--- a/uv.lock
+++ b/uv.lock
@@ -584,7 +584,7 @@ wheels = [
 
 [[package]]
 name = "qpc"
-version = "2.4.3"
+version = "2.5.0"
 source = { editable = "." }
 dependencies = [
     { name = "cryptography" },


### PR DESCRIPTION
Relates to JIRA: DISCOVERY-1287

## Summary by Sourcery

Build:
- Update project version metadata in pyproject.toml and RPM spec to 2.5.0.