### PR TITLE
chore: Remove upper Python version limit

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ name = "qpc"
 version = "2.5.0"
 description = "The command-line client for quipucords servers"
 authors = [{ name = "QPC Team", email = "quipucords@redhat.com" }]
-requires-python = ">=3.12,<3.14"
+requires-python = ">=3.12"
 license = { file = "LICENSE" }
 classifiers = ["License :: OSI Approved :: GNU General Public License v3 (GPLv3)"]
 dependencies = [

--- a/uv.lock
+++ b/uv.lock
@@ -1,6 +1,6 @@
 version = 1
 revision = 3
-requires-python = ">=3.12, <3.14"
+requires-python = ">=3.12"
 
 [[package]]
 name = "alabaster"


### PR DESCRIPTION
Fedora now defaults to Python 3.14, which makes installing qpc through pipx unnecessarily difficult.

Removal of upper version cap does not mean recommendation, endorsement, or official support.