### PR TITLE
feature: Add support for HashiCorp Vault credentials

### DIFF
--- a/docs/_build/QPC_VAR_PROGRAM_NAME.1
+++ b/docs/_build/QPC_VAR_PROGRAM_NAME.1
@@ -235,7 +235,7 @@ Prompts for the access token for authentication. Mutually exclusive with the \fB
 \fB\-\-vault\-secret\-path=path\fP
 .INDENT 0.0
 .INDENT 3.5
-Sets the HashiCorp Vault secret path for credential storage. Only valid for \fBopenshift\fP and \fBansible\fP credential types. When this option is used, credentials are retrieved from the configured HashiCorp Vault server instead of being stored in the QPC database. Mutually exclusive with the \fB\-\-username\fP, \fB\-\-password\fP, and \fB\-\-token\fP options.
+Sets the HashiCorp Vault secret path for credential storage. Only valid for \fBopenshift\fP and \fBansible\fP credential types. When this option is used, credentials are retrieved from the configured HashiCorp Vault server instead of being stored in the QPC database. Mutually exclusive with the \fB\-\-username\fP, \fB\-\-password\fP, \fB\-\-sshkeyfile\fP, and \fB\-\-token\fP options.
 .UNINDENT
 .UNINDENT
 .sp

--- a/docs/_build/QPC_VAR_PROGRAM_NAME.1
+++ b/docs/_build/QPC_VAR_PROGRAM_NAME.1
@@ -235,7 +235,7 @@ Prompts for the access token for authentication. Mutually exclusive with the \fB
 \fB\-\-vault\-secret\-path=path\fP
 .INDENT 0.0
 .INDENT 3.5
-Sets the HashiCorp Vault secret path for credential storage. Only valid for \fBopenshift\fP and \fBansible\fP credential types. When this option is used, credentials are retrieved from the configured HashiCorp Vault server instead of being stored in the QPC database. Cannot be used with \fB\-\-username\fP, \fB\-\-password\fP, or \fB\-\-token\fP options. Mutually exclusive with the \fB\-\-sshkeyfile\fP, \fB\-\-password\fP, and \fB\-\-token\fP options.
+Sets the HashiCorp Vault secret path for credential storage. Only valid for \fBopenshift\fP and \fBansible\fP credential types. When this option is used, credentials are retrieved from the configured HashiCorp Vault server instead of being stored in the QPC database. Mutually exclusive with the \fB\-\-username\fP, \fB\-\-password\fP, and \fB\-\-token\fP options.
 .UNINDENT
 .UNINDENT
 .sp

--- a/docs/_build/QPC_VAR_PROGRAM_NAME.1
+++ b/docs/_build/QPC_VAR_PROGRAM_NAME.1
@@ -160,7 +160,7 @@ When a scan runs, it uses a source that contains information such as the host na
 .sp
 To create a credential, supply the type of credential and supply SSH credentials as either a username\-password pair, a username\-key pair, or an access token. The QPC_VAR_PROJECT tool stores each set of credentials in a separate credential entry.
 .sp
-\fBQPC_VAR_PROGRAM_NAME cred add \-\-name=\fP \fIname\fP \fB\-\-type=\fP \fI(network | vcenter | satellite | openshift | rhacs | ansible)\fP \fB\-\-username=\fP \fIusername\fP (\fB\-\-password\fP | \fB\-\-sshkeyfile\fP \fI(ssh_keyfile | \-)\fP) \fB[\-\-sshpassphrase]\fP \fB\-\-become\-method=\fP \fI(sudo | su | pbrun | pfexec | doas | dzdo | ksu | runas )\fP \fB\-\-become\-user=\fP \fIuser\fP \fB[\-\-become\-password]\fP \fB[\-\-token]\fP
+\fBQPC_VAR_PROGRAM_NAME cred add \-\-name=\fP \fIname\fP \fB\-\-type=\fP \fI(network | vcenter | satellite | openshift | rhacs | ansible)\fP { \fB\-\-username=\fP \fIusername\fP (\fB\-\-password\fP | \fB\-\-sshkeyfile\fP \fI(ssh_keyfile | \-)\fP | \fB\-\-token\fP) | \fB\-\-vault\-secret\-path=\fP \fIpath\fP [\fB\-\-vault\-mount\-point=\fP \fImount_point\fP] } \fB[\-\-sshpassphrase]\fP \fB\-\-become\-method=\fP \fI(sudo | su | pbrun | pfexec | doas | dzdo | ksu | runas )\fP \fB\-\-become\-user=\fP \fIuser\fP \fB[\-\-become\-password]\fP
 .sp
 \fB\-\-name=name\fP
 .INDENT 0.0
@@ -228,13 +228,27 @@ Prompts for the privilege escalation password to be used when running a network 
 \fB\-\-token\fP
 .INDENT 0.0
 .INDENT 3.5
-Prompts for the access token for authentication. Mutually exclusive with the \fB\-\-sshkeyfile\fP and \fB\-\-password\fP options.
+Prompts for the access token for authentication. Mutually exclusive with the \fB\-\-sshkeyfile\fP, \fB\-\-password\fP, and \fB\-\-vault\-secret\-path\fP options.
+.UNINDENT
+.UNINDENT
+.sp
+\fB\-\-vault\-secret\-path=path\fP
+.INDENT 0.0
+.INDENT 3.5
+Sets the HashiCorp Vault secret path for credential storage. Only valid for \fBopenshift\fP and \fBansible\fP credential types. When this option is used, credentials are retrieved from the configured HashiCorp Vault server instead of being stored in the QPC database. Cannot be used with \fB\-\-username\fP, \fB\-\-password\fP, or \fB\-\-token\fP options. Mutually exclusive with the \fB\-\-sshkeyfile\fP, \fB\-\-password\fP, and \fB\-\-token\fP options.
+.UNINDENT
+.UNINDENT
+.sp
+\fB\-\-vault\-mount\-point=mount_point\fP
+.INDENT 0.0
+.INDENT 3.5
+Sets the HashiCorp Vault mount point. Only valid when \fB\-\-vault\-secret\-path\fP is also specified. This is optional and allows you to specify a custom secret engine mount point if your Vault configuration uses non\-default mount points. If not specified, the default mount point used for a Key/Value (KV) secrets engine is \fBsecret\fP\&.
 .UNINDENT
 .UNINDENT
 .sp
 The information in a credential might change, including passwords, become passwords, SSH keys, the become_method, tokens or even the username. For example, your local security policies might require you to change passwords periodically. Use the \fBQPC_VAR_PROGRAM_NAME cred edit\fP command to change credential information. The parameters for \fBQPC_VAR_PROGRAM_NAME cred edit\fP are the same as those for \fBQPC_VAR_PROGRAM_NAME cred add\fP\&.
 .sp
-\fBQPC_VAR_PROGRAM_NAME cred edit \-\-name=\fP \fIname\fP \fB\-\-username=\fP \fIusername\fP (\fB\-\-password\fP | \fB\-\-sshkeyfile\fP \fI(ssh_keyfile | \-)\fP) \fB[\-\-sshpassphrase]\fP \fB\-\-become\-method=\fP \fI(sudo | su | pbrun | pfexec | doas | dzdo | ksu | runas )\fP \fB\-\-become\-user=\fP \fIuser\fP \fB[\-\-become\-password]\fP \fB[\-\-token]\fP
+\fBQPC_VAR_PROGRAM_NAME cred edit \-\-name=\fP \fIname\fP \fB\-\-username=\fP \fIusername\fP (\fB\-\-password\fP | \fB\-\-sshkeyfile\fP \fI(ssh_keyfile | \-)\fP \fB| \-\-token | \-\-vault\-secret\-path\fP \fIpath\fP) \fB[\-\-sshpassphrase]\fP \fB\-\-become\-method=\fP \fI(sudo | su | pbrun | pfexec | doas | dzdo | ksu | runas )\fP \fB\-\-become\-user=\fP \fIuser\fP \fB[\-\-become\-password]\fP \fB[\-\-vault\-mount\-point\fP \fImount_point\fP \fB]\fP
 .SS Listing and Showing Credentials
 .sp
 The \fBQPC_VAR_PROGRAM_NAME cred list\fP command returns the details for every credential that is configured for QPC_VAR_PROJECT. This output includes the name and username for each entry. Secret values such as passwords and tokens are never displated in the output.
@@ -1003,6 +1017,10 @@ Creating a new openshift type credential with a token
 Creating a new openshift type credential with a password
 .sp
 \fBQPC_VAR_PROGRAM_NAME cred add \-\-name ocp_cred2 \-\-type openshift \-\-username ocp_user \-\-password\fP
+.IP \(bu 2
+Creating a new openshift type credential using a HashiCorp Vault secret
+.sp
+\fBQPC_VAR_PROGRAM_NAME cred add \-\-name ocp_cred3 \-\-type openshift \-\-vault\-secret\-path ocp3_secret\fP
 .IP \(bu 2
 Creating a new vcenter type credential
 .sp

--- a/docs/_build/man-qpc.rst
+++ b/docs/_build/man-qpc.rst
@@ -143,7 +143,8 @@ Creating and Editing Credentials
 
 To create a credential, supply the type of credential and supply SSH credentials as either a username-password pair, a username-key pair, or an access token. The Quipucords tool stores each set of credentials in a separate credential entry.
 
-**qpc cred add --name=** *name* **--type=** *(network | vcenter | satellite | openshift | rhacs | ansible)* **--username=** *username* (**--password** | **--sshkeyfile** *(ssh_keyfile | -)*) **[--sshpassphrase]** **--become-method=** *(sudo | su | pbrun | pfexec | doas | dzdo | ksu | runas )* **--become-user=** *user* **[--become-password]** **[--token]**
+**qpc cred add --name=** *name* **--type=** *(network | vcenter | satellite | openshift | rhacs | ansible)* { **--username=** *username* (**--password** | **--sshkeyfile** *(ssh_keyfile | -)* | **--token**) | **--vault-secret-path=** *path* [**--vault-mount-point=** *mount_point*] } **[--sshpassphrase]** **--become-method=** *(sudo | su | pbrun | pfexec | doas | dzdo | ksu | runas )* **--become-user=** *user* **[--become-password]**
+
 
 ``--name=name``
 
@@ -183,11 +184,19 @@ To create a credential, supply the type of credential and supply SSH credentials
 
 ``--token``
 
-  Prompts for the access token for authentication. Mutually exclusive with the ``--sshkeyfile`` and ``--password`` options.
+  Prompts for the access token for authentication. Mutually exclusive with the ``--sshkeyfile``, ``--password``, and ``--vault-secret-path`` options.
+
+``--vault-secret-path=path``
+
+  Sets the HashiCorp Vault secret path for credential storage. Only valid for ``openshift`` and ``ansible`` credential types. When this option is used, credentials are retrieved from the configured HashiCorp Vault server instead of being stored in the QPC database. Cannot be used with ``--username``, ``--password``, or ``--token`` options. Mutually exclusive with the ``--sshkeyfile``, ``--password``, and ``--token`` options.
+
+``--vault-mount-point=mount_point``
+
+  Sets the HashiCorp Vault mount point. Only valid when ``--vault-secret-path`` is also specified. This is optional and allows you to specify a custom secret engine mount point if your Vault configuration uses non-default mount points. If not specified, the default mount point used for a Key/Value (KV) secrets engine is **secret**.
 
 The information in a credential might change, including passwords, become passwords, SSH keys, the become_method, tokens or even the username. For example, your local security policies might require you to change passwords periodically. Use the ``qpc cred edit`` command to change credential information. The parameters for ``qpc cred edit`` are the same as those for ``qpc cred add``.
 
-**qpc cred edit --name=** *name* **--username=** *username* (**--password** | **--sshkeyfile** *(ssh_keyfile | -)*) **[--sshpassphrase]** **--become-method=** *(sudo | su | pbrun | pfexec | doas | dzdo | ksu | runas )* **--become-user=** *user* **[--become-password]** **[--token]**
+**qpc cred edit --name=** *name* **--username=** *username* (**--password** | **--sshkeyfile** *(ssh_keyfile | -)* **| --token | --vault-secret-path** *path*) **[--sshpassphrase]** **--become-method=** *(sudo | su | pbrun | pfexec | doas | dzdo | ksu | runas )* **--become-user=** *user* **[--become-password]** **[--vault-mount-point** *mount_point* **]**
 
 Listing and Showing Credentials
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -811,6 +820,10 @@ Examples
 * Creating a new openshift type credential with a password
 
   ``qpc cred add --name ocp_cred2 --type openshift --username ocp_user --password``
+
+* Creating a new openshift type credential using a HashiCorp Vault secret
+
+  ``qpc cred add --name ocp_cred3 --type openshift --vault-secret-path ocp3_secret``
 
 * Creating a new vcenter type credential
 

--- a/docs/_build/man-qpc.rst
+++ b/docs/_build/man-qpc.rst
@@ -188,7 +188,7 @@ To create a credential, supply the type of credential and supply SSH credentials
 
 ``--vault-secret-path=path``
 
-  Sets the HashiCorp Vault secret path for credential storage. Only valid for ``openshift`` and ``ansible`` credential types. When this option is used, credentials are retrieved from the configured HashiCorp Vault server instead of being stored in the QPC database. Mutually exclusive with the ``--username``, ``--password``, and ``--token`` options.
+  Sets the HashiCorp Vault secret path for credential storage. Only valid for ``openshift`` and ``ansible`` credential types. When this option is used, credentials are retrieved from the configured HashiCorp Vault server instead of being stored in the QPC database. Mutually exclusive with the ``--username``, ``--password``, ``--sshkeyfile``, and ``--token`` options.
 
 ``--vault-mount-point=mount_point``
 

--- a/docs/_build/man-qpc.rst
+++ b/docs/_build/man-qpc.rst
@@ -188,7 +188,7 @@ To create a credential, supply the type of credential and supply SSH credentials
 
 ``--vault-secret-path=path``
 
-  Sets the HashiCorp Vault secret path for credential storage. Only valid for ``openshift`` and ``ansible`` credential types. When this option is used, credentials are retrieved from the configured HashiCorp Vault server instead of being stored in the QPC database. Cannot be used with ``--username``, ``--password``, or ``--token`` options. Mutually exclusive with the ``--sshkeyfile``, ``--password``, and ``--token`` options.
+  Sets the HashiCorp Vault secret path for credential storage. Only valid for ``openshift`` and ``ansible`` credential types. When this option is used, credentials are retrieved from the configured HashiCorp Vault server instead of being stored in the QPC database. Mutually exclusive with the ``--username``, ``--password``, and ``--token`` options.
 
 ``--vault-mount-point=mount_point``
 

--- a/docs/_build/qpc.1
+++ b/docs/_build/qpc.1
@@ -27,7 +27,7 @@ level margin: \\n[rst2man-indent\\n[rst2man-indent-level]]
 .\" new: \\n[rst2man-indent\\n[rst2man-indent-level]]
 .in \\n[rst2man-indent\\n[rst2man-indent-level]]u
 ..
-.TH "qpc" "1" "April 16, 2026" "" "qpc"
+.TH "qpc" "1" "April 23, 2026" "" "qpc"
 .SH NAME
 .sp
 qpc \- Inspect and report on product entitlement metadata from various sources, including networks and systems management solutions.
@@ -160,7 +160,7 @@ When a scan runs, it uses a source that contains information such as the host na
 .sp
 To create a credential, supply the type of credential and supply SSH credentials as either a username\-password pair, a username\-key pair, or an access token. The Quipucords tool stores each set of credentials in a separate credential entry.
 .sp
-\fBqpc cred add \-\-name=\fP \fIname\fP \fB\-\-type=\fP \fI(network | vcenter | satellite | openshift | rhacs | ansible)\fP \fB\-\-username=\fP \fIusername\fP (\fB\-\-password\fP | \fB\-\-sshkeyfile\fP \fI(ssh_keyfile | \-)\fP) \fB[\-\-sshpassphrase]\fP \fB\-\-become\-method=\fP \fI(sudo | su | pbrun | pfexec | doas | dzdo | ksu | runas )\fP \fB\-\-become\-user=\fP \fIuser\fP \fB[\-\-become\-password]\fP \fB[\-\-token]\fP
+\fBqpc cred add \-\-name=\fP \fIname\fP \fB\-\-type=\fP \fI(network | vcenter | satellite | openshift | rhacs | ansible)\fP { \fB\-\-username=\fP \fIusername\fP (\fB\-\-password\fP | \fB\-\-sshkeyfile\fP \fI(ssh_keyfile | \-)\fP | \fB\-\-token\fP) | \fB\-\-vault\-secret\-path=\fP \fIpath\fP [\fB\-\-vault\-mount\-point=\fP \fImount_point\fP] } \fB[\-\-sshpassphrase]\fP \fB\-\-become\-method=\fP \fI(sudo | su | pbrun | pfexec | doas | dzdo | ksu | runas )\fP \fB\-\-become\-user=\fP \fIuser\fP \fB[\-\-become\-password]\fP
 .sp
 \fB\-\-name=name\fP
 .INDENT 0.0
@@ -228,13 +228,27 @@ Prompts for the privilege escalation password to be used when running a network 
 \fB\-\-token\fP
 .INDENT 0.0
 .INDENT 3.5
-Prompts for the access token for authentication. Mutually exclusive with the \fB\-\-sshkeyfile\fP and \fB\-\-password\fP options.
+Prompts for the access token for authentication. Mutually exclusive with the \fB\-\-sshkeyfile\fP, \fB\-\-password\fP, and \fB\-\-vault\-secret\-path\fP options.
+.UNINDENT
+.UNINDENT
+.sp
+\fB\-\-vault\-secret\-path=path\fP
+.INDENT 0.0
+.INDENT 3.5
+Sets the HashiCorp Vault secret path for credential storage. Only valid for \fBopenshift\fP and \fBansible\fP credential types. When this option is used, credentials are retrieved from the configured HashiCorp Vault server instead of being stored in the QPC database. Cannot be used with \fB\-\-username\fP, \fB\-\-password\fP, or \fB\-\-token\fP options. Mutually exclusive with the \fB\-\-sshkeyfile\fP, \fB\-\-password\fP, and \fB\-\-token\fP options.
+.UNINDENT
+.UNINDENT
+.sp
+\fB\-\-vault\-mount\-point=mount_point\fP
+.INDENT 0.0
+.INDENT 3.5
+Sets the HashiCorp Vault mount point. Only valid when \fB\-\-vault\-secret\-path\fP is also specified. This is optional and allows you to specify a custom secret engine mount point if your Vault configuration uses non\-default mount points. If not specified, the default mount point used for a Key/Value (KV) secrets engine is \fBsecret\fP\&.
 .UNINDENT
 .UNINDENT
 .sp
 The information in a credential might change, including passwords, become passwords, SSH keys, the become_method, tokens or even the username. For example, your local security policies might require you to change passwords periodically. Use the \fBqpc cred edit\fP command to change credential information. The parameters for \fBqpc cred edit\fP are the same as those for \fBqpc cred add\fP\&.
 .sp
-\fBqpc cred edit \-\-name=\fP \fIname\fP \fB\-\-username=\fP \fIusername\fP (\fB\-\-password\fP | \fB\-\-sshkeyfile\fP \fI(ssh_keyfile | \-)\fP) \fB[\-\-sshpassphrase]\fP \fB\-\-become\-method=\fP \fI(sudo | su | pbrun | pfexec | doas | dzdo | ksu | runas )\fP \fB\-\-become\-user=\fP \fIuser\fP \fB[\-\-become\-password]\fP \fB[\-\-token]\fP
+\fBqpc cred edit \-\-name=\fP \fIname\fP \fB\-\-username=\fP \fIusername\fP (\fB\-\-password\fP | \fB\-\-sshkeyfile\fP \fI(ssh_keyfile | \-)\fP \fB| \-\-token | \-\-vault\-secret\-path\fP \fIpath\fP) \fB[\-\-sshpassphrase]\fP \fB\-\-become\-method=\fP \fI(sudo | su | pbrun | pfexec | doas | dzdo | ksu | runas )\fP \fB\-\-become\-user=\fP \fIuser\fP \fB[\-\-become\-password]\fP \fB[\-\-vault\-mount\-point\fP \fImount_point\fP \fB]\fP
 .SS Listing and Showing Credentials
 .sp
 The \fBqpc cred list\fP command returns the details for every credential that is configured for Quipucords. This output includes the name and username for each entry. Secret values such as passwords and tokens are never displated in the output.
@@ -1003,6 +1017,10 @@ Creating a new openshift type credential with a token
 Creating a new openshift type credential with a password
 .sp
 \fBqpc cred add \-\-name ocp_cred2 \-\-type openshift \-\-username ocp_user \-\-password\fP
+.IP \(bu 2
+Creating a new openshift type credential using a HashiCorp Vault secret
+.sp
+\fBqpc cred add \-\-name ocp_cred3 \-\-type openshift \-\-vault\-secret\-path ocp3_secret\fP
 .IP \(bu 2
 Creating a new vcenter type credential
 .sp

--- a/docs/_build/qpc.1
+++ b/docs/_build/qpc.1
@@ -235,7 +235,7 @@ Prompts for the access token for authentication. Mutually exclusive with the \fB
 \fB\-\-vault\-secret\-path=path\fP
 .INDENT 0.0
 .INDENT 3.5
-Sets the HashiCorp Vault secret path for credential storage. Only valid for \fBopenshift\fP and \fBansible\fP credential types. When this option is used, credentials are retrieved from the configured HashiCorp Vault server instead of being stored in the QPC database. Cannot be used with \fB\-\-username\fP, \fB\-\-password\fP, or \fB\-\-token\fP options. Mutually exclusive with the \fB\-\-sshkeyfile\fP, \fB\-\-password\fP, and \fB\-\-token\fP options.
+Sets the HashiCorp Vault secret path for credential storage. Only valid for \fBopenshift\fP and \fBansible\fP credential types. When this option is used, credentials are retrieved from the configured HashiCorp Vault server instead of being stored in the QPC database. Mutually exclusive with the \fB\-\-username\fP, \fB\-\-password\fP, and \fB\-\-token\fP options.
 .UNINDENT
 .UNINDENT
 .sp

--- a/docs/_build/qpc.1
+++ b/docs/_build/qpc.1
@@ -27,7 +27,7 @@ level margin: \\n[rst2man-indent\\n[rst2man-indent-level]]
 .\" new: \\n[rst2man-indent\\n[rst2man-indent-level]]
 .in \\n[rst2man-indent\\n[rst2man-indent-level]]u
 ..
-.TH "qpc" "1" "April 23, 2026" "" "qpc"
+.TH "qpc" "1" "April 27, 2026" "" "qpc"
 .SH NAME
 .sp
 qpc \- Inspect and report on product entitlement metadata from various sources, including networks and systems management solutions.
@@ -235,7 +235,7 @@ Prompts for the access token for authentication. Mutually exclusive with the \fB
 \fB\-\-vault\-secret\-path=path\fP
 .INDENT 0.0
 .INDENT 3.5
-Sets the HashiCorp Vault secret path for credential storage. Only valid for \fBopenshift\fP and \fBansible\fP credential types. When this option is used, credentials are retrieved from the configured HashiCorp Vault server instead of being stored in the QPC database. Mutually exclusive with the \fB\-\-username\fP, \fB\-\-password\fP, and \fB\-\-token\fP options.
+Sets the HashiCorp Vault secret path for credential storage. Only valid for \fBopenshift\fP and \fBansible\fP credential types. When this option is used, credentials are retrieved from the configured HashiCorp Vault server instead of being stored in the QPC database. Mutually exclusive with the \fB\-\-username\fP, \fB\-\-password\fP, \fB\-\-sshkeyfile\fP, and \fB\-\-token\fP options.
 .UNINDENT
 .UNINDENT
 .sp

--- a/docs/source/man-template.rst
+++ b/docs/source/man-template.rst
@@ -188,7 +188,7 @@ To create a credential, supply the type of credential and supply SSH credentials
 
 ``--vault-secret-path=path``
 
-  Sets the HashiCorp Vault secret path for credential storage. Only valid for ``openshift`` and ``ansible`` credential types. When this option is used, credentials are retrieved from the configured HashiCorp Vault server instead of being stored in the QPC database. Mutually exclusive with the ``--username``, ``--password``, and ``--token`` options.
+  Sets the HashiCorp Vault secret path for credential storage. Only valid for ``openshift`` and ``ansible`` credential types. When this option is used, credentials are retrieved from the configured HashiCorp Vault server instead of being stored in the QPC database. Mutually exclusive with the ``--username``, ``--password``, ``--sshkeyfile``, and ``--token`` options.
 
 ``--vault-mount-point=mount_point``
 

--- a/docs/source/man-template.rst
+++ b/docs/source/man-template.rst
@@ -143,7 +143,8 @@ Creating and Editing Credentials
 
 To create a credential, supply the type of credential and supply SSH credentials as either a username-password pair, a username-key pair, or an access token. The QPC_VAR_PROJECT tool stores each set of credentials in a separate credential entry.
 
-**QPC_VAR_PROGRAM_NAME cred add --name=** *name* **--type=** *(network | vcenter | satellite | openshift | rhacs | ansible)* **--username=** *username* (**--password** | **--sshkeyfile** *(ssh_keyfile | -)*) **[--sshpassphrase]** **--become-method=** *(sudo | su | pbrun | pfexec | doas | dzdo | ksu | runas )* **--become-user=** *user* **[--become-password]** **[--token]**
+**QPC_VAR_PROGRAM_NAME cred add --name=** *name* **--type=** *(network | vcenter | satellite | openshift | rhacs | ansible)* { **--username=** *username* (**--password** | **--sshkeyfile** *(ssh_keyfile | -)* | **--token**) | **--vault-secret-path=** *path* [**--vault-mount-point=** *mount_point*] } **[--sshpassphrase]** **--become-method=** *(sudo | su | pbrun | pfexec | doas | dzdo | ksu | runas )* **--become-user=** *user* **[--become-password]**
+
 
 ``--name=name``
 
@@ -183,11 +184,19 @@ To create a credential, supply the type of credential and supply SSH credentials
 
 ``--token``
 
-  Prompts for the access token for authentication. Mutually exclusive with the ``--sshkeyfile`` and ``--password`` options.
+  Prompts for the access token for authentication. Mutually exclusive with the ``--sshkeyfile``, ``--password``, and ``--vault-secret-path`` options.
+
+``--vault-secret-path=path``
+
+  Sets the HashiCorp Vault secret path for credential storage. Only valid for ``openshift`` and ``ansible`` credential types. When this option is used, credentials are retrieved from the configured HashiCorp Vault server instead of being stored in the QPC database. Cannot be used with ``--username``, ``--password``, or ``--token`` options. Mutually exclusive with the ``--sshkeyfile``, ``--password``, and ``--token`` options.
+
+``--vault-mount-point=mount_point``
+
+  Sets the HashiCorp Vault mount point. Only valid when ``--vault-secret-path`` is also specified. This is optional and allows you to specify a custom secret engine mount point if your Vault configuration uses non-default mount points. If not specified, the default mount point used for a Key/Value (KV) secrets engine is **secret**.
 
 The information in a credential might change, including passwords, become passwords, SSH keys, the become_method, tokens or even the username. For example, your local security policies might require you to change passwords periodically. Use the ``QPC_VAR_PROGRAM_NAME cred edit`` command to change credential information. The parameters for ``QPC_VAR_PROGRAM_NAME cred edit`` are the same as those for ``QPC_VAR_PROGRAM_NAME cred add``.
 
-**QPC_VAR_PROGRAM_NAME cred edit --name=** *name* **--username=** *username* (**--password** | **--sshkeyfile** *(ssh_keyfile | -)*) **[--sshpassphrase]** **--become-method=** *(sudo | su | pbrun | pfexec | doas | dzdo | ksu | runas )* **--become-user=** *user* **[--become-password]** **[--token]**
+**QPC_VAR_PROGRAM_NAME cred edit --name=** *name* **--username=** *username* (**--password** | **--sshkeyfile** *(ssh_keyfile | -)* **| --token | --vault-secret-path** *path*) **[--sshpassphrase]** **--become-method=** *(sudo | su | pbrun | pfexec | doas | dzdo | ksu | runas )* **--become-user=** *user* **[--become-password]** **[--vault-mount-point** *mount_point* **]**
 
 Listing and Showing Credentials
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -811,6 +820,10 @@ Examples
 * Creating a new openshift type credential with a password
 
   ``QPC_VAR_PROGRAM_NAME cred add --name ocp_cred2 --type openshift --username ocp_user --password``
+
+* Creating a new openshift type credential using a HashiCorp Vault secret
+
+  ``QPC_VAR_PROGRAM_NAME cred add --name ocp_cred3 --type openshift --vault-secret-path ocp3_secret``
 
 * Creating a new vcenter type credential
 

--- a/docs/source/man-template.rst
+++ b/docs/source/man-template.rst
@@ -188,7 +188,7 @@ To create a credential, supply the type of credential and supply SSH credentials
 
 ``--vault-secret-path=path``
 
-  Sets the HashiCorp Vault secret path for credential storage. Only valid for ``openshift`` and ``ansible`` credential types. When this option is used, credentials are retrieved from the configured HashiCorp Vault server instead of being stored in the QPC database. Cannot be used with ``--username``, ``--password``, or ``--token`` options. Mutually exclusive with the ``--sshkeyfile``, ``--password``, and ``--token`` options.
+  Sets the HashiCorp Vault secret path for credential storage. Only valid for ``openshift`` and ``ansible`` credential types. When this option is used, credentials are retrieved from the configured HashiCorp Vault server instead of being stored in the QPC database. Mutually exclusive with the ``--username``, ``--password``, and ``--token`` options.
 
 ``--vault-mount-point=mount_point``
 

--- a/qpc/cred/add.py
+++ b/qpc/cred/add.py
@@ -1,5 +1,6 @@
 """CredAddCommand is used to add authentication credentials."""
 
+import sys
 from logging import getLogger
 
 from requests import codes
@@ -79,6 +80,19 @@ class CredAddCommand(CliCommand):
             action="store_true",
             help=_(messages.CRED_TOKEN_HELP),
         )
+        group.add_argument(
+            "--vault-secret-path",
+            dest="vault_secret_path",
+            metavar="VAULT_SECRET_PATH",
+            help=_(messages.CRED_VAULT_SECRET_PATH_HELP),
+        )
+        self.parser.add_argument(
+            "--vault-mount-point",
+            dest="vault_mount_point",
+            metavar="VAULT_MOUNT_POINT",
+            help=_(messages.CRED_VAULT_MOUNT_POINT_HELP),
+            required=False,
+        )
         self.parser.add_argument(
             "--sshpassphrase",
             dest="ssh_passphrase",
@@ -104,6 +118,30 @@ class CredAddCommand(CliCommand):
             action="store_true",
             help=_(messages.CRED_BECOME_PASSWORD_HELP),
         )
+
+    def _validate_args(self):
+        """Validate command arguments."""
+        CliCommand._validate_args(self)
+
+        # Get vault options (use getattr for legacy test compatibility)
+        vault_secret_path = getattr(self.args, "vault_secret_path", None)
+        vault_mount_point = getattr(self.args, "vault_mount_point", None)
+
+        # Validate vault options are only used with openshift or ansible types
+        if vault_secret_path:
+            if self.args.type not in ["openshift", "ansible"]:
+                logger.error(_(messages.CRED_VAULT_INVALID_TYPE))
+                sys.exit(1)
+
+            # vault_secret_path cannot be used with username
+            if self.args.username:
+                logger.error(_(messages.CRED_VAULT_EXCLUSIVE_WITH_CREDS))
+                sys.exit(1)
+
+        # vault_mount_point can only be specified if vault_secret_path is specified
+        if vault_mount_point and not vault_secret_path:
+            logger.error(_(messages.CRED_VAULT_MOUNT_REQUIRES_PATH))
+            sys.exit(1)
 
     def _build_data(self):
         """Construct the dictionary credential given our arguments.

--- a/qpc/cred/add.py
+++ b/qpc/cred/add.py
@@ -1,6 +1,5 @@
 """CredAddCommand is used to add authentication credentials."""
 
-import sys
 from logging import getLogger
 
 from requests import codes
@@ -8,7 +7,7 @@ from requests import codes
 import qpc.cred as credential
 from qpc import messages
 from qpc.clicommand import CliCommand
-from qpc.cred.utils import build_credential_payload
+from qpc.cred.utils import build_credential_payload, validate_vault_args
 from qpc.request import POST
 from qpc.source import SOURCE_TYPE_CHOICES
 from qpc.translation import _
@@ -123,25 +122,8 @@ class CredAddCommand(CliCommand):
         """Validate command arguments."""
         CliCommand._validate_args(self)
 
-        # Get vault options (use getattr for legacy test compatibility)
-        vault_secret_path = getattr(self.args, "vault_secret_path", None)
-        vault_mount_point = getattr(self.args, "vault_mount_point", None)
-
-        # Validate vault options are only used with openshift or ansible types
-        if vault_secret_path:
-            if self.args.type not in ["openshift", "ansible"]:
-                logger.error(_(messages.CRED_VAULT_INVALID_TYPE))
-                sys.exit(1)
-
-            # vault_secret_path cannot be used with username
-            if self.args.username:
-                logger.error(_(messages.CRED_VAULT_EXCLUSIVE_WITH_CREDS))
-                sys.exit(1)
-
-        # vault_mount_point can only be specified if vault_secret_path is specified
-        if vault_mount_point and not vault_secret_path:
-            logger.error(_(messages.CRED_VAULT_MOUNT_REQUIRES_PATH))
-            sys.exit(1)
+        # Validate vault options
+        validate_vault_args(self.args)
 
     def _build_data(self):
         """Construct the dictionary credential given our arguments.

--- a/qpc/cred/edit.py
+++ b/qpc/cred/edit.py
@@ -63,12 +63,11 @@ class CredEditCommand(CliCommand):
             action="store_true",
             help=_(messages.CRED_TOKEN_HELP),
         )
-        self.parser.add_argument(
+        group.add_argument(
             "--vault-secret-path",
             dest="vault_secret_path",
             metavar="VAULT_SECRET_PATH",
             help=_(messages.CRED_VAULT_SECRET_PATH_HELP),
-            required=False,
         )
         self.parser.add_argument(
             "--vault-mount-point",

--- a/qpc/cred/edit.py
+++ b/qpc/cred/edit.py
@@ -63,6 +63,20 @@ class CredEditCommand(CliCommand):
             action="store_true",
             help=_(messages.CRED_TOKEN_HELP),
         )
+        self.parser.add_argument(
+            "--vault-secret-path",
+            dest="vault_secret_path",
+            metavar="VAULT_SECRET_PATH",
+            help=_(messages.CRED_VAULT_SECRET_PATH_HELP),
+            required=False,
+        )
+        self.parser.add_argument(
+            "--vault-mount-point",
+            dest="vault_mount_point",
+            metavar="VAULT_MOUNT_POINT",
+            help=_(messages.CRED_VAULT_MOUNT_POINT_HELP),
+            required=False,
+        )
         group.add_argument(
             "--sshkeyfile",
             dest="ssh_keyfile",
@@ -99,6 +113,10 @@ class CredEditCommand(CliCommand):
     def _validate_args(self):
         CliCommand._validate_args(self)
 
+        # Get vault options (use getattr for legacy test compatibility)
+        vault_secret_path = getattr(self.args, "vault_secret_path", None)
+        vault_mount_point = getattr(self.args, "vault_mount_point", None)
+
         if not (
             self.args.username
             or self.args.password
@@ -108,6 +126,8 @@ class CredEditCommand(CliCommand):
             or self.args.become_user
             or self.args.become_password
             or self.args.token
+            or vault_secret_path
+            or vault_mount_point
         ):
             logger.error(_(messages.CRED_EDIT_NO_ARGS), self.args.name)
             self.parser.print_help()
@@ -133,6 +153,22 @@ class CredEditCommand(CliCommand):
                 sys.exit(1)
         else:
             logger.error(_(messages.CRED_DOES_NOT_EXIST), self.args.name)
+            sys.exit(1)
+
+        # Validate vault options are only used with openshift or ansible types
+        if vault_secret_path:
+            if self.cred_type not in ["openshift", "ansible"]:
+                logger.error(_(messages.CRED_VAULT_INVALID_TYPE))
+                sys.exit(1)
+
+            # vault_secret_path cannot be used with username/password or token
+            if self.args.username or self.args.password or self.args.token:
+                logger.error(_(messages.CRED_VAULT_EXCLUSIVE_WITH_CREDS))
+                sys.exit(1)
+
+        # vault_mount_point can only be specified if vault_secret_path is specified
+        if vault_mount_point and not vault_secret_path:
+            logger.error(_(messages.CRED_VAULT_MOUNT_REQUIRES_PATH))
             sys.exit(1)
 
     def _build_data(self):

--- a/qpc/cred/edit.py
+++ b/qpc/cred/edit.py
@@ -8,7 +8,7 @@ from requests import codes
 import qpc.cred as credential
 from qpc import messages
 from qpc.clicommand import CliCommand
-from qpc.cred.utils import build_credential_payload
+from qpc.cred.utils import build_credential_payload, validate_vault_args
 from qpc.request import GET, PATCH, request
 from qpc.translation import _
 
@@ -155,21 +155,8 @@ class CredEditCommand(CliCommand):
             logger.error(_(messages.CRED_DOES_NOT_EXIST), self.args.name)
             sys.exit(1)
 
-        # Validate vault options are only used with openshift or ansible types
-        if vault_secret_path:
-            if self.cred_type not in ["openshift", "ansible"]:
-                logger.error(_(messages.CRED_VAULT_INVALID_TYPE))
-                sys.exit(1)
-
-            # vault_secret_path cannot be used with username/password or token
-            if self.args.username or self.args.password or self.args.token:
-                logger.error(_(messages.CRED_VAULT_EXCLUSIVE_WITH_CREDS))
-                sys.exit(1)
-
-        # vault_mount_point can only be specified if vault_secret_path is specified
-        if vault_mount_point and not vault_secret_path:
-            logger.error(_(messages.CRED_VAULT_MOUNT_REQUIRES_PATH))
-            sys.exit(1)
+        # Validate vault options
+        validate_vault_args(self.args, self.cred_type)
 
     def _build_data(self):
         """Construct the dictionary credential given our arguments.

--- a/qpc/cred/utils.py
+++ b/qpc/cred/utils.py
@@ -158,3 +158,39 @@ def get_multiline_pass(prompt="Password: "):
         sys.stderr.flush()
     sys.stderr.write("\n")
     return "".join(multiline_password)
+
+
+def validate_vault_args(args, cred_type=None):
+    """Validate vault-related credential arguments.
+
+    :param args: The command line arguments
+    :param cred_type: The credential type (for edit command, None for add)
+    :returns: None
+    :raises SystemExit: If validation fails
+    """
+    # Get vault options (use getattr for legacy test compatibility)
+    vault_secret_path = getattr(args, "vault_secret_path", None)
+    vault_mount_point = getattr(args, "vault_mount_point", None)
+
+    if vault_secret_path:
+        # Determine credential type from args or parameter
+        check_type = cred_type if cred_type else getattr(args, "type", None)
+
+        # Vault options are only valid for openshift and ansible types
+        if check_type not in ["openshift", "ansible"]:
+            logger.error(_(messages.CRED_VAULT_INVALID_TYPE))
+            sys.exit(1)
+
+        # vault_secret_path cannot be used with username/password/token
+        if (
+            getattr(args, "username", None)
+            or getattr(args, "password", None)
+            or getattr(args, "token", None)
+        ):
+            logger.error(_(messages.CRED_VAULT_EXCLUSIVE_WITH_CREDS))
+            sys.exit(1)
+
+    # vault_mount_point can only be specified if vault_secret_path is specified
+    if vault_mount_point and not vault_secret_path:
+        logger.error(_(messages.CRED_VAULT_MOUNT_REQUIRES_PATH))
+        sys.exit(1)

--- a/qpc/cred/utils.py
+++ b/qpc/cred/utils.py
@@ -181,10 +181,11 @@ def validate_vault_args(args, cred_type=None):
             logger.error(_(messages.CRED_VAULT_INVALID_TYPE))
             sys.exit(1)
 
-        # vault_secret_path cannot be used with username/password/token
+        # vault_secret_path cannot be used with username/password/sshkeyfile/token
         if (
             getattr(args, "username", None)
             or getattr(args, "password", None)
+            or getattr(args, "ssh_keyfile", None)
             or getattr(args, "token", None)
         ):
             logger.error(_(messages.CRED_VAULT_EXCLUSIVE_WITH_CREDS))

--- a/qpc/cred/utils.py
+++ b/qpc/cred/utils.py
@@ -127,6 +127,10 @@ def build_credential_payload(args, cred_type, add_none=True):
         req_payload["become_method"] = args.become_method
     if "become_user" in args and args.become_user:
         req_payload["become_user"] = args.become_user
+    if "vault_secret_path" in args and args.vault_secret_path:
+        req_payload["vault_secret_path"] = args.vault_secret_path
+    if "vault_mount_point" in args and args.vault_mount_point:
+        req_payload["vault_mount_point"] = args.vault_mount_point
 
     req_payload = get_password(args, req_payload, add_none)
     return req_payload

--- a/qpc/messages.py
+++ b/qpc/messages.py
@@ -61,7 +61,7 @@ CRED_TOKEN_HELP = "Authentication token."
 CRED_VAULT_SECRET_PATH_HELP = (
     "HashiCorp Vault secret path for credential storage. "
     "Only valid for openshift and ansible credential types. "
-    "Cannot be used with --username/--password or --token."
+    "Cannot be used with --username, --password, --sshkeyfile, or --token."
 )
 CRED_VAULT_MOUNT_POINT_HELP = (
     "Optional HashiCorp Vault mount point. "
@@ -73,7 +73,7 @@ CRED_VAULT_INVALID_TYPE = (
 )
 CRED_VAULT_EXCLUSIVE_WITH_CREDS = (
     "The --vault-secret-path option cannot be used with "
-    "--username, --password, or --token."
+    "--username, --password, --sshkeyfile, or --token."
 )
 CRED_VAULT_MOUNT_REQUIRES_PATH = (
     "The --vault-mount-point option can only be specified "

--- a/qpc/messages.py
+++ b/qpc/messages.py
@@ -58,6 +58,27 @@ CRED_BECOME_PASSWORD_HELP = (
     "The privilege escalation password to be used when running a network scan."
 )
 CRED_TOKEN_HELP = "Authentication token."
+CRED_VAULT_SECRET_PATH_HELP = (
+    "HashiCorp Vault secret path for credential storage. "
+    "Only valid for openshift and ansible credential types. "
+    "Cannot be used with --username/--password or --token."
+)
+CRED_VAULT_MOUNT_POINT_HELP = (
+    "Optional HashiCorp Vault mount point. "
+    "Only valid when --vault-secret-path is specified."
+)
+CRED_VAULT_INVALID_TYPE = (
+    "The --vault-secret-path option is only valid for "
+    "openshift and ansible credential types."
+)
+CRED_VAULT_EXCLUSIVE_WITH_CREDS = (
+    "The --vault-secret-path option cannot be used with "
+    "--username, --password, or --token."
+)
+CRED_VAULT_MOUNT_REQUIRES_PATH = (
+    "The --vault-mount-point option can only be specified "
+    "when --vault-secret-path is also specified."
+)
 
 SOURCE_NAME_HELP = "Source name."
 SOURCES_NAME_HELP = "List of source names."

--- a/qpc/tests/cred/test_openshift_cred_add.py
+++ b/qpc/tests/cred/test_openshift_cred_add.py
@@ -91,7 +91,11 @@ class TestOpenShiftAddCredential:
             CLI().main()
         out, err = capsys.readouterr()
         assert out == ""
-        assert "one of the arguments --password --sshkeyfile --token is required" in err
+        expected_error = (
+            "one of the arguments --password --sshkeyfile "
+            "--token --vault-secret-path is required"
+        )
+        assert expected_error in err
 
     def test_add_no_name(
         self,

--- a/qpc/tests/cred/test_vault_cred_add.py
+++ b/qpc/tests/cred/test_vault_cred_add.py
@@ -1,0 +1,200 @@
+"""Test vault credential add in CLI."""
+
+import sys
+from unittest.mock import patch
+
+import pytest
+
+from qpc import messages
+from qpc.cli import CLI
+from qpc.cred import CREDENTIAL_URI, OPENSHIFT_CRED_TYPE
+from qpc.source import ANSIBLE_SOURCE_TYPE
+from qpc.utils import get_server_location
+
+
+class TestVaultAddCredential:
+    """Class for testing vault credential add."""
+
+    @patch("sys.stdin.isatty")
+    def test_add_vault_openshift_green_path(
+        self,
+        mock_isatty,
+        caplog,
+        requests_mock,
+    ):
+        """Test openshift cred add with vault secret path."""
+        caplog.set_level("INFO")
+        mock_isatty.return_value = True
+        url = get_server_location() + CREDENTIAL_URI
+        requests_mock.post(url, status_code=201)
+        sys.argv = [
+            "/bin/qpc",
+            "cred",
+            "add",
+            "--name",
+            "openshift_vault_credential",
+            "--type",
+            OPENSHIFT_CRED_TYPE,
+            "--vault-secret-path",
+            "secret/data/my-creds",
+        ]
+        CLI().main()
+        assert caplog.messages[-1] == messages.CRED_ADDED % "openshift_vault_credential"
+
+    @patch("sys.stdin.isatty")
+    def test_add_vault_ansible_green_path(
+        self,
+        mock_isatty,
+        caplog,
+        requests_mock,
+    ):
+        """Test ansible cred add with vault secret path."""
+        caplog.set_level("INFO")
+        mock_isatty.return_value = True
+        url = get_server_location() + CREDENTIAL_URI
+        requests_mock.post(url, status_code=201)
+        sys.argv = [
+            "/bin/qpc",
+            "cred",
+            "add",
+            "--name",
+            "ansible_vault_credential",
+            "--type",
+            ANSIBLE_SOURCE_TYPE,
+            "--vault-secret-path",
+            "secret/data/my-creds",
+        ]
+        CLI().main()
+        assert caplog.messages[-1] == messages.CRED_ADDED % "ansible_vault_credential"
+
+    @patch("sys.stdin.isatty")
+    def test_add_vault_with_mount_point(
+        self,
+        mock_isatty,
+        caplog,
+        requests_mock,
+    ):
+        """Test openshift cred add with vault secret path and mount point."""
+        caplog.set_level("INFO")
+        mock_isatty.return_value = True
+        url = get_server_location() + CREDENTIAL_URI
+        requests_mock.post(url, status_code=201)
+        sys.argv = [
+            "/bin/qpc",
+            "cred",
+            "add",
+            "--name",
+            "openshift_vault_credential",
+            "--type",
+            OPENSHIFT_CRED_TYPE,
+            "--vault-secret-path",
+            "secret/data/my-creds",
+            "--vault-mount-point",
+            "custom-mount",
+        ]
+        CLI().main()
+        assert caplog.messages[-1] == messages.CRED_ADDED % "openshift_vault_credential"
+
+    def test_add_vault_invalid_type(
+        self,
+        capsys,
+    ):
+        """Test vault secret path with invalid credential type."""
+        sys.argv = [
+            "/bin/qpc",
+            "cred",
+            "add",
+            "--name",
+            "network_vault_credential",
+            "--type",
+            "network",
+            "--vault-secret-path",
+            "secret/data/my-creds",
+        ]
+        with pytest.raises(SystemExit):
+            CLI().main()
+        out, err = capsys.readouterr()
+        assert messages.CRED_VAULT_INVALID_TYPE in err
+
+    @patch("sys.stdin.isatty")
+    def test_add_vault_with_username(
+        self,
+        mock_isatty,
+        capsys,
+        requests_mock,
+    ):
+        """Test that vault secret path with username fails."""
+        mock_isatty.return_value = True
+        url = get_server_location() + CREDENTIAL_URI
+        requests_mock.post(url, status_code=201)
+        sys.argv = [
+            "/bin/qpc",
+            "cred",
+            "add",
+            "--name",
+            "openshift_vault_credential",
+            "--type",
+            OPENSHIFT_CRED_TYPE,
+            "--username",
+            "admin",
+            "--vault-secret-path",
+            "secret/data/my-creds",
+        ]
+        with pytest.raises(SystemExit):
+            CLI().main()
+        out, err = capsys.readouterr()
+        assert messages.CRED_VAULT_EXCLUSIVE_WITH_CREDS in err
+
+    @patch("sys.stdin.isatty")
+    def test_add_vault_mount_without_path(
+        self,
+        mock_isatty,
+        capsys,
+        requests_mock,
+        openshift_token_input,
+    ):
+        """Test that vault mount point without vault secret path fails."""
+        mock_isatty.return_value = True
+        url = get_server_location() + CREDENTIAL_URI
+        requests_mock.post(url, status_code=201)
+        sys.argv = [
+            "/bin/qpc",
+            "cred",
+            "add",
+            "--name",
+            "openshift_vault_credential",
+            "--type",
+            OPENSHIFT_CRED_TYPE,
+            "--token",
+            "--vault-mount-point",
+            "custom-mount",
+        ]
+        with pytest.raises(SystemExit):
+            CLI().main()
+        out, err = capsys.readouterr()
+        assert messages.CRED_VAULT_MOUNT_REQUIRES_PATH in err
+
+    @patch("sys.stdin.isatty")
+    def test_add_vault_with_token_mutually_exclusive(
+        self,
+        mock_isatty,
+        capsys,
+    ):
+        """Test that vault secret path and token are mutually exclusive."""
+        mock_isatty.return_value = True
+        sys.argv = [
+            "/bin/qpc",
+            "cred",
+            "add",
+            "--name",
+            "openshift_vault_credential",
+            "--type",
+            OPENSHIFT_CRED_TYPE,
+            "--token",
+            "--vault-secret-path",
+            "secret/data/my-creds",
+        ]
+        with pytest.raises(SystemExit):
+            CLI().main()
+        out, err = capsys.readouterr()
+        assert "not allowed with argument" in err

--- a/qpc/tests/cred/test_vault_cred_add.py
+++ b/qpc/tests/cred/test_vault_cred_add.py
@@ -67,6 +67,12 @@ class TestVaultAddCredential:
         CLI().main()
         assert caplog.messages[-1] == messages.CRED_ADDED % "ansible_vault_credential"
 
+        # Validate outgoing request payload
+        payload = requests_mock.last_request.json()
+        assert payload["vault_secret_path"] == "secret/data/my-creds"
+        # Mount point should not be present when not provided
+        assert "vault_mount_point" not in payload
+
     @patch("sys.stdin.isatty")
     def test_add_vault_with_mount_point(
         self,
@@ -94,6 +100,11 @@ class TestVaultAddCredential:
         ]
         CLI().main()
         assert caplog.messages[-1] == messages.CRED_ADDED % "openshift_vault_credential"
+
+        # Validate outgoing request payload includes mount point when provided
+        payload = requests_mock.last_request.json()
+        assert payload["vault_secret_path"] == "secret/data/my-creds"
+        assert payload["vault_mount_point"] == "custom-mount"
 
     def test_add_vault_invalid_type(
         self,

--- a/qpc/tests/cred/test_vault_cred_add.py
+++ b/qpc/tests/cred/test_vault_cred_add.py
@@ -186,6 +186,32 @@ class TestVaultAddCredential:
         assert messages.CRED_VAULT_MOUNT_REQUIRES_PATH in err
 
     @patch("sys.stdin.isatty")
+    def test_add_vault_with_sshkeyfile_mutually_exclusive(
+        self,
+        mock_isatty,
+        capsys,
+    ):
+        """Test that vault secret path and sshkeyfile are mutually exclusive."""
+        mock_isatty.return_value = True
+        sys.argv = [
+            "/bin/qpc",
+            "cred",
+            "add",
+            "--name",
+            "openshift_vault_credential",
+            "--type",
+            OPENSHIFT_CRED_TYPE,
+            "--sshkeyfile",
+            "/path/to/key",
+            "--vault-secret-path",
+            "secret/data/my-creds",
+        ]
+        with pytest.raises(SystemExit):
+            CLI().main()
+        out, err = capsys.readouterr()
+        assert "not allowed with argument" in err
+
+    @patch("sys.stdin.isatty")
     def test_add_vault_with_token_mutually_exclusive(
         self,
         mock_isatty,

--- a/qpc/tests/cred/test_vault_cred_edit.py
+++ b/qpc/tests/cred/test_vault_cred_edit.py
@@ -84,6 +84,12 @@ class TestVaultEditCredential:
         CLI().main()
         assert caplog.messages[-1] == messages.CRED_UPDATED % "ansible_cred"
 
+        # Validate outgoing request payload
+        payload = requests_mock.last_request.json()
+        assert payload["vault_secret_path"] == "secret/data/my-creds"
+        # Mount point should not be present when not provided
+        assert "vault_mount_point" not in payload
+
     @patch("sys.stdin.isatty")
     def test_edit_vault_with_mount_point(
         self,
@@ -121,6 +127,11 @@ class TestVaultEditCredential:
         ]
         CLI().main()
         assert caplog.messages[-1] == messages.CRED_UPDATED % "openshift_cred"
+
+        # Validate outgoing request payload includes mount point when provided
+        payload = requests_mock.last_request.json()
+        assert payload["vault_secret_path"] == "secret/data/my-creds"
+        assert payload["vault_mount_point"] == "custom-mount"
 
     def test_edit_vault_invalid_type(
         self,

--- a/qpc/tests/cred/test_vault_cred_edit.py
+++ b/qpc/tests/cred/test_vault_cred_edit.py
@@ -1,0 +1,219 @@
+"""Test vault credential edit in CLI."""
+
+import sys
+from unittest.mock import patch
+
+import pytest
+
+from qpc import messages
+from qpc.cli import CLI
+from qpc.cred import CREDENTIAL_URI
+from qpc.utils import get_server_location
+
+
+class TestVaultEditCredential:
+    """Class for testing vault credential edit."""
+
+    @patch("sys.stdin.isatty")
+    def test_edit_vault_openshift_green_path(
+        self,
+        mock_isatty,
+        caplog,
+        requests_mock,
+    ):
+        """Test openshift cred edit with vault secret path."""
+        caplog.set_level("INFO")
+        mock_isatty.return_value = True
+        url = get_server_location() + CREDENTIAL_URI
+        # Mock the GET request to check if credential exists
+        requests_mock.get(
+            url,
+            status_code=200,
+            json={
+                "count": 1,
+                "results": [
+                    {"id": 1, "name": "openshift_cred", "cred_type": "openshift"}
+                ],
+            },
+        )
+        # Mock the PATCH request to update the credential
+        requests_mock.patch(url + "1/", status_code=200)
+        sys.argv = [
+            "/bin/qpc",
+            "cred",
+            "edit",
+            "--name",
+            "openshift_cred",
+            "--vault-secret-path",
+            "secret/data/my-creds",
+        ]
+        CLI().main()
+        assert caplog.messages[-1] == messages.CRED_UPDATED % "openshift_cred"
+
+    @patch("sys.stdin.isatty")
+    def test_edit_vault_ansible_green_path(
+        self,
+        mock_isatty,
+        caplog,
+        requests_mock,
+    ):
+        """Test ansible cred edit with vault secret path."""
+        caplog.set_level("INFO")
+        mock_isatty.return_value = True
+        url = get_server_location() + CREDENTIAL_URI
+        # Mock the GET request to check if credential exists
+        requests_mock.get(
+            url,
+            status_code=200,
+            json={
+                "count": 1,
+                "results": [{"id": 1, "name": "ansible_cred", "cred_type": "ansible"}],
+            },
+        )
+        # Mock the PATCH request to update the credential
+        requests_mock.patch(url + "1/", status_code=200)
+        sys.argv = [
+            "/bin/qpc",
+            "cred",
+            "edit",
+            "--name",
+            "ansible_cred",
+            "--vault-secret-path",
+            "secret/data/my-creds",
+        ]
+        CLI().main()
+        assert caplog.messages[-1] == messages.CRED_UPDATED % "ansible_cred"
+
+    @patch("sys.stdin.isatty")
+    def test_edit_vault_with_mount_point(
+        self,
+        mock_isatty,
+        caplog,
+        requests_mock,
+    ):
+        """Test openshift cred edit with vault secret path and mount point."""
+        caplog.set_level("INFO")
+        mock_isatty.return_value = True
+        url = get_server_location() + CREDENTIAL_URI
+        # Mock the GET request to check if credential exists
+        requests_mock.get(
+            url,
+            status_code=200,
+            json={
+                "count": 1,
+                "results": [
+                    {"id": 1, "name": "openshift_cred", "cred_type": "openshift"}
+                ],
+            },
+        )
+        # Mock the PATCH request to update the credential
+        requests_mock.patch(url + "1/", status_code=200)
+        sys.argv = [
+            "/bin/qpc",
+            "cred",
+            "edit",
+            "--name",
+            "openshift_cred",
+            "--vault-secret-path",
+            "secret/data/my-creds",
+            "--vault-mount-point",
+            "custom-mount",
+        ]
+        CLI().main()
+        assert caplog.messages[-1] == messages.CRED_UPDATED % "openshift_cred"
+
+    def test_edit_vault_invalid_type(
+        self,
+        capsys,
+        requests_mock,
+    ):
+        """Test vault secret path with invalid credential type."""
+        url = get_server_location() + CREDENTIAL_URI
+        # Mock the GET request to check if credential exists
+        requests_mock.get(
+            url,
+            status_code=200,
+            json={
+                "count": 1,
+                "results": [{"id": 1, "name": "network_cred", "cred_type": "network"}],
+            },
+        )
+        sys.argv = [
+            "/bin/qpc",
+            "cred",
+            "edit",
+            "--name",
+            "network_cred",
+            "--vault-secret-path",
+            "secret/data/my-creds",
+        ]
+        with pytest.raises(SystemExit):
+            CLI().main()
+        out, err = capsys.readouterr()
+        assert messages.CRED_VAULT_INVALID_TYPE in err
+
+    def test_edit_vault_with_username(
+        self,
+        capsys,
+        requests_mock,
+    ):
+        """Test that vault secret path with username fails."""
+        url = get_server_location() + CREDENTIAL_URI
+        # Mock the GET request to check if credential exists
+        requests_mock.get(
+            url,
+            status_code=200,
+            json={
+                "count": 1,
+                "results": [
+                    {"id": 1, "name": "openshift_cred", "cred_type": "openshift"}
+                ],
+            },
+        )
+        sys.argv = [
+            "/bin/qpc",
+            "cred",
+            "edit",
+            "--name",
+            "openshift_cred",
+            "--username",
+            "admin",
+            "--vault-secret-path",
+            "secret/data/my-creds",
+        ]
+        with pytest.raises(SystemExit):
+            CLI().main()
+        out, err = capsys.readouterr()
+        assert messages.CRED_VAULT_EXCLUSIVE_WITH_CREDS in err
+
+    def test_edit_vault_mount_without_path(
+        self,
+        capsys,
+        requests_mock,
+    ):
+        """Test vault mount point without vault secret path fails."""
+        url = get_server_location() + CREDENTIAL_URI
+        # Mock the GET request to check if credential exists
+        requests_mock.get(
+            url,
+            status_code=200,
+            json={
+                "count": 1,
+                "results": [
+                    {"id": 1, "name": "openshift_cred", "cred_type": "openshift"}
+                ],
+            },
+        )
+        sys.argv = [
+            "/bin/qpc",
+            "cred",
+            "edit",
+            "--name",
+            "openshift_cred",
+            "--vault-mount-point",
+            "custom-mount",
+        ]
+        with pytest.raises(SystemExit):
+            CLI().main()
+        out, err = capsys.readouterr()
+        assert messages.CRED_VAULT_MOUNT_REQUIRES_PATH in err

--- a/qpc/tests/cred/test_vault_cred_edit.py
+++ b/qpc/tests/cred/test_vault_cred_edit.py
@@ -197,6 +197,39 @@ class TestVaultEditCredential:
         out, err = capsys.readouterr()
         assert messages.CRED_VAULT_EXCLUSIVE_WITH_CREDS in err
 
+    def test_edit_vault_with_sshkeyfile_mutually_exclusive(
+        self,
+        capsys,
+        requests_mock,
+    ):
+        """Test that vault secret path and sshkeyfile are mutually exclusive."""
+        url = get_server_location() + CREDENTIAL_URI
+        requests_mock.get(
+            url,
+            status_code=200,
+            json={
+                "count": 1,
+                "results": [
+                    {"id": 1, "name": "openshift_cred", "cred_type": "openshift"}
+                ],
+            },
+        )
+        sys.argv = [
+            "/bin/qpc",
+            "cred",
+            "edit",
+            "--name",
+            "openshift_cred",
+            "--sshkeyfile",
+            "/path/to/key",
+            "--vault-secret-path",
+            "secret/data/my-creds",
+        ]
+        with pytest.raises(SystemExit):
+            CLI().main()
+        out, err = capsys.readouterr()
+        assert "not allowed with argument" in err
+
     def test_edit_vault_mount_without_path(
         self,
         capsys,


### PR DESCRIPTION
- Add support for the HashiCorp Vault credentials by introducing the `--vault-secret-path` and `--vault-mount-point` options to the following credential subcommands:
  - qpc cred add
  - qpc cred edit
- Update tests
- Update the manual page and related generated docs

Depends on: https://github.com/quipucords/quipucords/pull/3160

Resolves: https://redhat.atlassian.net/browse/DISCOVERY-1298

## Summary by Sourcery

Add HashiCorp Vault-backed credential support to the CLI and document its usage.

New Features:
- Introduce --vault-secret-path and --vault-mount-point options for qpc cred add and qpc cred edit to reference credentials stored in HashiCorp Vault for openshift and ansible types.

Enhancements:
- Extend credential payload construction to include Vault secret path and mount point when provided.

Documentation:
- Update man pages and examples to describe the new Vault-based credential options, constraints, and usage patterns.

Tests:
- Add and update CLI tests to cover Vault-backed credential add/edit flows, validation rules, and argument exclusivity.

## Summary by Sourcery

Add HashiCorp Vault-backed credential support to the CLI for add/edit operations and document the new options and constraints.

New Features:
- Introduce --vault-secret-path and --vault-mount-point options for qpc cred add and qpc cred edit to reference credentials stored in HashiCorp Vault.
- Extend credential payloads to include Vault secret path and mount point when provided.

Enhancements:
- Add centralized validation for Vault-related CLI arguments, including supported credential types and exclusivity with existing credential fields.

Documentation:
- Update man pages and generated CLI documentation with the new Vault options, usage examples, and argument exclusivity rules.

Tests:
- Add and update CLI tests for Vault-backed credential add/edit flows, payload construction, and validation of invalid combinations of arguments.