### PR TITLE
fix: remove the ssl_verify flag and now require a ca_cert for vault

### DIFF
--- a/docs/_build/QPC_VAR_PROGRAM_NAME.1
+++ b/docs/_build/QPC_VAR_PROGRAM_NAME.1
@@ -921,7 +921,7 @@ Use the \fBQPC_VAR_PROGRAM_NAME vault\fP command to configure HashiCorp Vault in
 .sp
 To initially configure HashiCorp Vault integration, use the \fBvault add\fP subcommand. This command requires the Vault server address and mutual TLS (mTLS) authentication certificates.
 .sp
-\fBQPC_VAR_PROGRAM_NAME vault add \-\-address=\fP \fIaddress\fP \fB[\-\-port=\fP \fIport\fP \fB]\fP \fB\-\-client\-cert=\fP \fIclient_cert_file\fP \fB\-\-client\-key=\fP \fIclient_key_file\fP \fB[\-\-ca\-cert=\fP \fIca_cert_file\fP \fB]\fP \fB[\-\-ssl\-verify=\fP \fI(true | false)\fP \fB]\fP
+\fBQPC_VAR_PROGRAM_NAME vault add \-\-address=\fP \fIaddress\fP \fB[\-\-port=\fP \fIport\fP \fB]\fP \fB\-\-client\-cert=\fP \fIclient_cert_file\fP \fB\-\-client\-key=\fP \fIclient_key_file\fP \fB\-\-ca\-cert=\fP \fIca_cert_file\fP
 .sp
 \fB\-\-address=address\fP
 .INDENT 0.0
@@ -954,26 +954,19 @@ Required. Sets the path to the client key file to use for mTLS authentication.
 \fB\-\-ca\-cert=ca_cert_file\fP
 .INDENT 0.0
 .INDENT 3.5
-Optional, but required when \fB\-\-ssl\-verify\fP is \fBtrue\fP\&. Sets the path to the CA certificate file to use for SSL verification.
-.UNINDENT
-.UNINDENT
-.sp
-\fB\-\-ssl\-verify=(true | false)\fP
-.INDENT 0.0
-.INDENT 3.5
-Optional. Determines whether to verify SSL certificates. The default is \fBtrue\fP\&.
+Required. Sets the path to the CA certificate file to use for SSL verification.
 .UNINDENT
 .UNINDENT
 .SS Editing Vault Configuration
 .sp
 To modify specific fields in the existing HashiCorp Vault configuration, use the \fBvault edit\fP subcommand. This command allows you to update one or more configuration parameters without having to specify all parameters.
 .sp
-\fBQPC_VAR_PROGRAM_NAME vault edit [\-\-address=\fP \fIaddress\fP \fB] [\-\-port=\fP \fIport\fP \fB] [\-\-client\-cert=\fP \fIclient_cert_file\fP \fB] [\-\-client\-key=\fP \fIclient_key_file\fP \fB] [\-\-ca\-cert=\fP \fIca_cert_file\fP \fB] [\-\-ssl\-verify=\fP \fI(true | false)\fP \fB]\fP
+\fBQPC_VAR_PROGRAM_NAME vault edit [\-\-address=\fP \fIaddress\fP \fB] [\-\-port=\fP \fIport\fP \fB] [\-\-client\-cert=\fP \fIclient_cert_file\fP \fB\-\-client\-key=\fP \fIclient_key_file\fP \fB] [\-\-ca\-cert=\fP \fIca_cert_file\fP \fB]\fP
 .sp
 All options are optional, but at least one must be provided. When updating client certificates, both \fB\-\-client\-cert\fP and \fB\-\-client\-key\fP must be provided together.
 .SS Showing Vault Configuration
 .sp
-To view the current HashiCorp Vault configuration, use the \fBvault show\fP subcommand. This command displays the vault server address, port, and SSL verification settings. For security reasons, certificate, key and CA Cert data are not displayed.
+To view the current HashiCorp Vault configuration, use the \fBvault show\fP subcommand. This command displays the vault server address and port. For security reasons, certificate, key and CA Cert data are not displayed.
 .sp
 \fBQPC_VAR_PROGRAM_NAME vault show\fP
 .SS Clearing Vault Configuration
@@ -1185,13 +1178,9 @@ Publishing to Insights using a previously downloaded report
 .sp
 \fBQPC_VAR_PROGRAM_NAME insights publish \-\-input\-file path_to_report.tar.gz\fP
 .IP \(bu 2
-Setting up HashiCorp Vault integration with a CA certificate
+Setting up HashiCorp Vault integration
 .sp
-\fBQPC_VAR_PROGRAM_NAME vault add \-\-address vault.example.com \-\-port 8200 \-\-client\-cert /path/to/client.pem \-\-client\-key /path/to/client\-key.pem \-\-ca\-cert /path/to/ca.pem \-\-ssl\-verify true\fP
-.IP \(bu 2
-Setting up HashiCorp Vault integration without SSL verification
-.sp
-\fBQPC_VAR_PROGRAM_NAME vault add \-\-address vault.example.com \-\-client\-cert /path/to/client.pem \-\-client\-key /path/to/client\-key.pem \-\-ssl\-verify false\fP
+\fBQPC_VAR_PROGRAM_NAME vault add \-\-address vault.example.com \-\-port 8200 \-\-client\-cert /path/to/client.pem \-\-client\-key /path/to/client\-key.pem \-\-ca\-cert /path/to/ca.pem\fP
 .IP \(bu 2
 Editing only the HashiCorp Vault server address
 .sp
@@ -1201,9 +1190,9 @@ Editing the HashiCorp Vault client certificates
 .sp
 \fBQPC_VAR_PROGRAM_NAME vault edit \-\-client\-cert /path/to/updated\-client.pem \-\-client\-key /path/to/updated\-client\-key.pem\fP
 .IP \(bu 2
-Editing Vault CA certificate and SSL verification
+Editing the Vault CA certificate
 .sp
-\fBQPC_VAR_PROGRAM_NAME vault edit \-\-ca\-cert /path/to/new\-ca.pem \-\-ssl\-verify true\fP
+\fBQPC_VAR_PROGRAM_NAME vault edit \-\-ca\-cert /path/to/new\-ca.pem\fP
 .IP \(bu 2
 Showing the current HashiCorp Vault configuration
 .sp

--- a/docs/_build/man-qpc.rst
+++ b/docs/_build/man-qpc.rst
@@ -735,7 +735,7 @@ Adding Vault Configuration
 
 To initially configure HashiCorp Vault integration, use the ``vault add`` subcommand. This command requires the Vault server address and mutual TLS (mTLS) authentication certificates.
 
-**qpc vault add --address=** *address* **[--port=** *port* **]** **--client-cert=** *client_cert_file* **--client-key=** *client_key_file* **[--ca-cert=** *ca_cert_file* **]** **[--ssl-verify=** *(true | false)* **]**
+**qpc vault add --address=** *address* **[--port=** *port* **]** **--client-cert=** *client_cert_file* **--client-key=** *client_key_file* **--ca-cert=** *ca_cert_file*
 
 ``--address=address``
 
@@ -755,25 +755,21 @@ To initially configure HashiCorp Vault integration, use the ``vault add`` subcom
 
 ``--ca-cert=ca_cert_file``
 
-  Optional, but required when ``--ssl-verify`` is ``true``. Sets the path to the CA certificate file to use for SSL verification.
-
-``--ssl-verify=(true | false)``
-
-  Optional. Determines whether to verify SSL certificates. The default is ``true``.
+  Required. Sets the path to the CA certificate file to use for SSL verification.
 
 Editing Vault Configuration
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 To modify specific fields in the existing HashiCorp Vault configuration, use the ``vault edit`` subcommand. This command allows you to update one or more configuration parameters without having to specify all parameters.
 
-**qpc vault edit [--address=** *address* **] [--port=** *port* **] [--client-cert=** *client_cert_file* **] [--client-key=** *client_key_file* **] [--ca-cert=** *ca_cert_file* **] [--ssl-verify=** *(true | false)* **]**
+**qpc vault edit [--address=** *address* **] [--port=** *port* **] [--client-cert=** *client_cert_file* **--client-key=** *client_key_file* **] [--ca-cert=** *ca_cert_file* **]**
 
 All options are optional, but at least one must be provided. When updating client certificates, both ``--client-cert`` and ``--client-key`` must be provided together.
 
 Showing Vault Configuration
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-To view the current HashiCorp Vault configuration, use the ``vault show`` subcommand. This command displays the vault server address, port, and SSL verification settings. For security reasons, certificate, key and CA Cert data are not displayed.
+To view the current HashiCorp Vault configuration, use the ``vault show`` subcommand. This command displays the vault server address and port. For security reasons, certificate, key and CA Cert data are not displayed.
 
 **qpc vault show**
 
@@ -985,13 +981,9 @@ Examples
 
   ``qpc insights publish --input-file path_to_report.tar.gz``
 
-* Setting up HashiCorp Vault integration with a CA certificate
+* Setting up HashiCorp Vault integration
 
-  ``qpc vault add --address vault.example.com --port 8200 --client-cert /path/to/client.pem --client-key /path/to/client-key.pem --ca-cert /path/to/ca.pem --ssl-verify true``
-
-* Setting up HashiCorp Vault integration without SSL verification
-
-  ``qpc vault add --address vault.example.com --client-cert /path/to/client.pem --client-key /path/to/client-key.pem --ssl-verify false``
+  ``qpc vault add --address vault.example.com --port 8200 --client-cert /path/to/client.pem --client-key /path/to/client-key.pem --ca-cert /path/to/ca.pem``
 
 * Editing only the HashiCorp Vault server address
 
@@ -1001,9 +993,9 @@ Examples
 
   ``qpc vault edit --client-cert /path/to/updated-client.pem --client-key /path/to/updated-client-key.pem``
 
-* Editing Vault CA certificate and SSL verification
+* Editing the Vault CA certificate
 
-  ``qpc vault edit --ca-cert /path/to/new-ca.pem --ssl-verify true``
+  ``qpc vault edit --ca-cert /path/to/new-ca.pem``
 
 * Showing the current HashiCorp Vault configuration
 

--- a/docs/_build/qpc.1
+++ b/docs/_build/qpc.1
@@ -27,7 +27,7 @@ level margin: \\n[rst2man-indent\\n[rst2man-indent-level]]
 .\" new: \\n[rst2man-indent\\n[rst2man-indent-level]]
 .in \\n[rst2man-indent\\n[rst2man-indent-level]]u
 ..
-.TH "qpc" "1" "May 13, 2026" "" "qpc"
+.TH "qpc" "1" "July 16, 2026" "" "qpc"
 .SH NAME
 .sp
 qpc \- Inspect and report on product entitlement metadata from various sources, including networks and systems management solutions.
@@ -921,7 +921,7 @@ Use the \fBqpc vault\fP command to configure HashiCorp Vault integration for sec
 .sp
 To initially configure HashiCorp Vault integration, use the \fBvault add\fP subcommand. This command requires the Vault server address and mutual TLS (mTLS) authentication certificates.
 .sp
-\fBqpc vault add \-\-address=\fP \fIaddress\fP \fB[\-\-port=\fP \fIport\fP \fB]\fP \fB\-\-client\-cert=\fP \fIclient_cert_file\fP \fB\-\-client\-key=\fP \fIclient_key_file\fP \fB[\-\-ca\-cert=\fP \fIca_cert_file\fP \fB]\fP \fB[\-\-ssl\-verify=\fP \fI(true | false)\fP \fB]\fP
+\fBqpc vault add \-\-address=\fP \fIaddress\fP \fB[\-\-port=\fP \fIport\fP \fB]\fP \fB\-\-client\-cert=\fP \fIclient_cert_file\fP \fB\-\-client\-key=\fP \fIclient_key_file\fP \fB\-\-ca\-cert=\fP \fIca_cert_file\fP
 .sp
 \fB\-\-address=address\fP
 .INDENT 0.0
@@ -954,26 +954,19 @@ Required. Sets the path to the client key file to use for mTLS authentication.
 \fB\-\-ca\-cert=ca_cert_file\fP
 .INDENT 0.0
 .INDENT 3.5
-Optional, but required when \fB\-\-ssl\-verify\fP is \fBtrue\fP\&. Sets the path to the CA certificate file to use for SSL verification.
-.UNINDENT
-.UNINDENT
-.sp
-\fB\-\-ssl\-verify=(true | false)\fP
-.INDENT 0.0
-.INDENT 3.5
-Optional. Determines whether to verify SSL certificates. The default is \fBtrue\fP\&.
+Required. Sets the path to the CA certificate file to use for SSL verification.
 .UNINDENT
 .UNINDENT
 .SS Editing Vault Configuration
 .sp
 To modify specific fields in the existing HashiCorp Vault configuration, use the \fBvault edit\fP subcommand. This command allows you to update one or more configuration parameters without having to specify all parameters.
 .sp
-\fBqpc vault edit [\-\-address=\fP \fIaddress\fP \fB] [\-\-port=\fP \fIport\fP \fB] [\-\-client\-cert=\fP \fIclient_cert_file\fP \fB] [\-\-client\-key=\fP \fIclient_key_file\fP \fB] [\-\-ca\-cert=\fP \fIca_cert_file\fP \fB] [\-\-ssl\-verify=\fP \fI(true | false)\fP \fB]\fP
+\fBqpc vault edit [\-\-address=\fP \fIaddress\fP \fB] [\-\-port=\fP \fIport\fP \fB] [\-\-client\-cert=\fP \fIclient_cert_file\fP \fB\-\-client\-key=\fP \fIclient_key_file\fP \fB] [\-\-ca\-cert=\fP \fIca_cert_file\fP \fB]\fP
 .sp
 All options are optional, but at least one must be provided. When updating client certificates, both \fB\-\-client\-cert\fP and \fB\-\-client\-key\fP must be provided together.
 .SS Showing Vault Configuration
 .sp
-To view the current HashiCorp Vault configuration, use the \fBvault show\fP subcommand. This command displays the vault server address, port, and SSL verification settings. For security reasons, certificate, key and CA Cert data are not displayed.
+To view the current HashiCorp Vault configuration, use the \fBvault show\fP subcommand. This command displays the vault server address and port. For security reasons, certificate, key and CA Cert data are not displayed.
 .sp
 \fBqpc vault show\fP
 .SS Clearing Vault Configuration
@@ -1185,13 +1178,9 @@ Publishing to Insights using a previously downloaded report
 .sp
 \fBqpc insights publish \-\-input\-file path_to_report.tar.gz\fP
 .IP \(bu 2
-Setting up HashiCorp Vault integration with a CA certificate
+Setting up HashiCorp Vault integration
 .sp
-\fBqpc vault add \-\-address vault.example.com \-\-port 8200 \-\-client\-cert /path/to/client.pem \-\-client\-key /path/to/client\-key.pem \-\-ca\-cert /path/to/ca.pem \-\-ssl\-verify true\fP
-.IP \(bu 2
-Setting up HashiCorp Vault integration without SSL verification
-.sp
-\fBqpc vault add \-\-address vault.example.com \-\-client\-cert /path/to/client.pem \-\-client\-key /path/to/client\-key.pem \-\-ssl\-verify false\fP
+\fBqpc vault add \-\-address vault.example.com \-\-port 8200 \-\-client\-cert /path/to/client.pem \-\-client\-key /path/to/client\-key.pem \-\-ca\-cert /path/to/ca.pem\fP
 .IP \(bu 2
 Editing only the HashiCorp Vault server address
 .sp
@@ -1201,9 +1190,9 @@ Editing the HashiCorp Vault client certificates
 .sp
 \fBqpc vault edit \-\-client\-cert /path/to/updated\-client.pem \-\-client\-key /path/to/updated\-client\-key.pem\fP
 .IP \(bu 2
-Editing Vault CA certificate and SSL verification
+Editing the Vault CA certificate
 .sp
-\fBqpc vault edit \-\-ca\-cert /path/to/new\-ca.pem \-\-ssl\-verify true\fP
+\fBqpc vault edit \-\-ca\-cert /path/to/new\-ca.pem\fP
 .IP \(bu 2
 Showing the current HashiCorp Vault configuration
 .sp

--- a/docs/source/man-template.rst
+++ b/docs/source/man-template.rst
@@ -735,7 +735,7 @@ Adding Vault Configuration
 
 To initially configure HashiCorp Vault integration, use the ``vault add`` subcommand. This command requires the Vault server address and mutual TLS (mTLS) authentication certificates.
 
-**QPC_VAR_PROGRAM_NAME vault add --address=** *address* **[--port=** *port* **]** **--client-cert=** *client_cert_file* **--client-key=** *client_key_file* **[--ca-cert=** *ca_cert_file* **]** **[--ssl-verify=** *(true | false)* **]**
+**QPC_VAR_PROGRAM_NAME vault add --address=** *address* **[--port=** *port* **]** **--client-cert=** *client_cert_file* **--client-key=** *client_key_file* **--ca-cert=** *ca_cert_file*
 
 ``--address=address``
 
@@ -755,25 +755,21 @@ To initially configure HashiCorp Vault integration, use the ``vault add`` subcom
 
 ``--ca-cert=ca_cert_file``
 
-  Optional, but required when ``--ssl-verify`` is ``true``. Sets the path to the CA certificate file to use for SSL verification.
-
-``--ssl-verify=(true | false)``
-
-  Optional. Determines whether to verify SSL certificates. The default is ``true``.
+  Required. Sets the path to the CA certificate file to use for SSL verification.
 
 Editing Vault Configuration
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 To modify specific fields in the existing HashiCorp Vault configuration, use the ``vault edit`` subcommand. This command allows you to update one or more configuration parameters without having to specify all parameters.
 
-**QPC_VAR_PROGRAM_NAME vault edit [--address=** *address* **] [--port=** *port* **] [--client-cert=** *client_cert_file* **] [--client-key=** *client_key_file* **] [--ca-cert=** *ca_cert_file* **] [--ssl-verify=** *(true | false)* **]**
+**QPC_VAR_PROGRAM_NAME vault edit [--address=** *address* **] [--port=** *port* **] [--client-cert=** *client_cert_file* **--client-key=** *client_key_file* **] [--ca-cert=** *ca_cert_file* **]**
 
 All options are optional, but at least one must be provided. When updating client certificates, both ``--client-cert`` and ``--client-key`` must be provided together.
 
 Showing Vault Configuration
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-To view the current HashiCorp Vault configuration, use the ``vault show`` subcommand. This command displays the vault server address, port, and SSL verification settings. For security reasons, certificate, key and CA Cert data are not displayed.
+To view the current HashiCorp Vault configuration, use the ``vault show`` subcommand. This command displays the vault server address and port. For security reasons, certificate, key and CA Cert data are not displayed.
 
 **QPC_VAR_PROGRAM_NAME vault show**
 
@@ -985,13 +981,9 @@ Examples
 
   ``QPC_VAR_PROGRAM_NAME insights publish --input-file path_to_report.tar.gz``
 
-* Setting up HashiCorp Vault integration with a CA certificate
+* Setting up HashiCorp Vault integration
 
-  ``QPC_VAR_PROGRAM_NAME vault add --address vault.example.com --port 8200 --client-cert /path/to/client.pem --client-key /path/to/client-key.pem --ca-cert /path/to/ca.pem --ssl-verify true``
-
-* Setting up HashiCorp Vault integration without SSL verification
-
-  ``QPC_VAR_PROGRAM_NAME vault add --address vault.example.com --client-cert /path/to/client.pem --client-key /path/to/client-key.pem --ssl-verify false``
+  ``QPC_VAR_PROGRAM_NAME vault add --address vault.example.com --port 8200 --client-cert /path/to/client.pem --client-key /path/to/client-key.pem --ca-cert /path/to/ca.pem``
 
 * Editing only the HashiCorp Vault server address
 
@@ -1001,9 +993,9 @@ Examples
 
   ``QPC_VAR_PROGRAM_NAME vault edit --client-cert /path/to/updated-client.pem --client-key /path/to/updated-client-key.pem``
 
-* Editing Vault CA certificate and SSL verification
+* Editing the Vault CA certificate
 
-  ``QPC_VAR_PROGRAM_NAME vault edit --ca-cert /path/to/new-ca.pem --ssl-verify true``
+  ``QPC_VAR_PROGRAM_NAME vault edit --ca-cert /path/to/new-ca.pem``
 
 * Showing the current HashiCorp Vault configuration
 

--- a/qpc/messages.py
+++ b/qpc/messages.py
@@ -415,24 +415,14 @@ UNKNOWN_FILE_EXTENSION = "ERROR: unknown file extension"
 VAULT_ADDRESS_HELP = "HashiCorp Vault server address."
 VAULT_PORT_HELP = "HashiCorp Vault server port (default: 8200)."
 VAULT_PORT_HELP_NO_DEFAULT = "HashiCorp Vault server port."
-VAULT_SSL_VERIFY_HELP = (
-    "Enable/disable SSL certificate verification for Vault connection."
-    " Valid values: true, false. (default: true)"
-)
 VAULT_CLIENT_CERT_HELP = "Path to the Client certificate file for mTLS authentication."
 VAULT_CLIENT_KEY_HELP = "Path to the Client key file for mTLS authentication."
-VAULT_CA_CERT_HELP = (
-    "Path to the CA certificate file for SSL verification"
-    " (required when --ssl-verify true is specified)."
-)
+VAULT_CA_CERT_HELP = "Path to the CA certificate file for SSL verification."
 VAULT_CONFIG_SUCCESS = "HashiCorp Vault configuration was successfully configured."
 VAULT_UPDATED = "HashiCorp Vault configuration was updated."
 VAULT_CLEARED = "HashiCorp Vault configuration was cleared."
 VAULT_EDIT_NO_ARGS = (
     "No arguments were provided to edit the HashiCorp Vault configuration."
-)
-VAULT_CA_CERT_REQUIRED = (
-    "The --ca-cert option is required when ssl-verify is true (default behavior)."
 )
 VAULT_CLIENT_CERT_KEY_MISMATCH = (
     "Both --client-cert and --client-key options must be provided together."

--- a/qpc/tests/vault/test_vault_add.py
+++ b/qpc/tests/vault/test_vault_add.py
@@ -38,7 +38,6 @@ class TestVaultAddCli:
             args = Namespace(
                 address="vault.example.com",
                 port=8200,
-                ssl_verify="true",
                 client_cert=str(client_cert),
                 client_key=str(client_key),
                 ca_cert=str(ca_cert),
@@ -58,7 +57,6 @@ class TestVaultAddCli:
             args = Namespace(
                 address="vault.example.com",
                 port=8200,
-                ssl_verify="true",
                 client_cert=str(client_cert),
                 client_key=str(client_key),
                 ca_cert=str(ca_cert),
@@ -66,43 +64,6 @@ class TestVaultAddCli:
             with caplog.at_level(logging.INFO):
                 self.command.main(args)
                 assert messages.VAULT_CONFIG_SUCCESS in caplog.text
-
-    def test_add_vault_without_ca_cert_when_ssl_verify_false(
-        self, client_cert, client_key, caplog
-    ):
-        """Test adding vault configuration without CA cert when ssl_verify is false."""
-        url = get_server_location() + vault.VAULT_URI
-
-        with requests_mock.Mocker() as mocker:
-            mocker.post(url, status_code=201)
-            args = Namespace(
-                address="vault.example.com",
-                port=8200,
-                ssl_verify="false",
-                client_cert=str(client_cert),
-                client_key=str(client_key),
-                ca_cert=None,
-            )
-            with caplog.at_level(logging.INFO):
-                self.command.main(args)
-                assert messages.VAULT_CONFIG_SUCCESS in caplog.text
-
-    def test_add_vault_missing_ca_cert_when_ssl_verify_true(
-        self, client_cert, client_key, caplog
-    ):
-        """Test adding vault with ssl_verify true but missing CA cert fails."""
-        args = Namespace(
-            address="vault.example.com",
-            port=8200,
-            ssl_verify="true",
-            client_cert=str(client_cert),
-            client_key=str(client_key),
-            ca_cert=None,
-        )
-
-        with pytest.raises(SystemExit), caplog.at_level(logging.ERROR):
-            self.command.main(args)
-        assert messages.VAULT_CA_CERT_REQUIRED in caplog.text
 
     def test_add_vault_ssl_err(self, client_cert, client_key, ca_cert, caplog):
         """Test adding vault configuration with SSL error."""
@@ -118,7 +79,6 @@ class TestVaultAddCli:
             args = Namespace(
                 address="vault.example.com",
                 port=8200,
-                ssl_verify="true",
                 client_cert=str(client_cert),
                 client_key=str(client_key),
                 ca_cert=str(ca_cert),
@@ -141,7 +101,6 @@ class TestVaultAddCli:
             args = Namespace(
                 address="vault.example.com",
                 port=8200,
-                ssl_verify="true",
                 client_cert=str(client_cert),
                 client_key=str(client_key),
                 ca_cert=str(ca_cert),
@@ -160,7 +119,6 @@ class TestVaultAddCli:
             args = Namespace(
                 address="vault.example.com",
                 port=8200,
-                ssl_verify="true",
                 client_cert=str(client_cert),
                 client_key=str(client_key),
                 ca_cert=str(ca_cert),
@@ -183,7 +141,6 @@ class TestVaultAddCli:
             args = Namespace(
                 address="vault.example.com",
                 port=8200,
-                ssl_verify="true",
                 client_cert=str(client_cert),
                 client_key=str(client_key),
                 ca_cert=str(ca_cert),
@@ -197,7 +154,6 @@ class TestVaultAddCli:
         args = Namespace(
             address="vault.example.com",
             port=8200,
-            ssl_verify="true",
             client_cert="/nonexistent/client.pem",
             client_key="/nonexistent/client-key.pem",
             ca_cert="/nonexistent/ca.pem",
@@ -216,7 +172,6 @@ class TestVaultAddCli:
             args = Namespace(
                 address="vault.example.com",
                 port=9200,
-                ssl_verify="true",
                 client_cert=str(client_cert),
                 client_key=str(client_key),
                 ca_cert=str(ca_cert),

--- a/qpc/tests/vault/test_vault_edit.py
+++ b/qpc/tests/vault/test_vault_edit.py
@@ -38,7 +38,6 @@ class TestVaultEditCli:
             args = Namespace(
                 address="new-vault.example.com",
                 port=None,
-                ssl_verify=None,
                 client_cert=None,
                 client_key=None,
                 ca_cert=None,
@@ -57,7 +56,6 @@ class TestVaultEditCli:
             args = Namespace(
                 address=new_address,
                 port=None,
-                ssl_verify=None,
                 client_cert=None,
                 client_key=None,
                 ca_cert=None,
@@ -79,25 +77,6 @@ class TestVaultEditCli:
             args = Namespace(
                 address=None,
                 port=9200,
-                ssl_verify=None,
-                client_cert=None,
-                client_key=None,
-                ca_cert=None,
-            )
-            with caplog.at_level(logging.INFO):
-                self.command.main(args)
-                assert messages.VAULT_UPDATED in caplog.text
-
-    def test_edit_vault_ssl_verify_only(self, caplog):
-        """Test editing vault configuration with ssl_verify only."""
-        url = get_server_location() + vault.VAULT_URI
-
-        with requests_mock.Mocker() as mocker:
-            mocker.patch(url, status_code=200)
-            args = Namespace(
-                address=None,
-                port=None,
-                ssl_verify="false",
                 client_cert=None,
                 client_key=None,
                 ca_cert=None,
@@ -115,7 +94,6 @@ class TestVaultEditCli:
             args = Namespace(
                 address=None,
                 port=None,
-                ssl_verify=None,
                 client_cert=None,
                 client_key=None,
                 ca_cert=str(ca_cert),
@@ -133,7 +111,6 @@ class TestVaultEditCli:
             args = Namespace(
                 address=None,
                 port=None,
-                ssl_verify=None,
                 client_cert=str(client_cert),
                 client_key=str(client_key),
                 ca_cert=None,
@@ -151,7 +128,6 @@ class TestVaultEditCli:
             args = Namespace(
                 address="new-vault.example.com",
                 port=9200,
-                ssl_verify="true",
                 client_cert=None,
                 client_key=None,
                 ca_cert=str(ca_cert),
@@ -165,7 +141,6 @@ class TestVaultEditCli:
         args = Namespace(
             address=None,
             port=None,
-            ssl_verify=None,
             client_cert=None,
             client_key=None,
             ca_cert=None,
@@ -180,7 +155,6 @@ class TestVaultEditCli:
         args = Namespace(
             address=None,
             port=None,
-            ssl_verify=None,
             client_cert=str(client_cert),
             client_key=None,
             ca_cert=None,
@@ -195,7 +169,6 @@ class TestVaultEditCli:
         args = Namespace(
             address=None,
             port=None,
-            ssl_verify=None,
             client_cert=None,
             client_key=str(client_key),
             ca_cert=None,
@@ -219,7 +192,6 @@ class TestVaultEditCli:
             args = Namespace(
                 address="vault.example.com",
                 port=None,
-                ssl_verify=None,
                 client_cert=None,
                 client_key=None,
                 ca_cert=None,
@@ -242,7 +214,6 @@ class TestVaultEditCli:
             args = Namespace(
                 address="vault.example.com",
                 port=None,
-                ssl_verify=None,
                 client_cert=None,
                 client_key=None,
                 ca_cert=None,
@@ -261,7 +232,6 @@ class TestVaultEditCli:
             args = Namespace(
                 address="vault.example.com",
                 port=None,
-                ssl_verify=None,
                 client_cert=None,
                 client_key=None,
                 ca_cert=None,
@@ -284,7 +254,6 @@ class TestVaultEditCli:
             args = Namespace(
                 address="vault.example.com",
                 port=None,
-                ssl_verify=None,
                 client_cert=None,
                 client_key=None,
                 ca_cert=None,
@@ -302,7 +271,6 @@ class TestVaultEditCli:
             args = Namespace(
                 address="new-vault.example.com",
                 port=9200,
-                ssl_verify="false",
                 client_cert=str(client_cert),
                 client_key=str(client_key),
                 ca_cert=str(ca_cert),

--- a/qpc/tests/vault/test_vault_show.py
+++ b/qpc/tests/vault/test_vault_show.py
@@ -38,7 +38,6 @@ class TestVaultShowCli:
         vault_data = {
             "address": "vault.example.com",
             "port": 8200,
-            "ssl_verify": True,
         }
 
         with requests_mock.Mocker() as mocker:
@@ -58,7 +57,6 @@ class TestVaultShowCli:
         vault_data = {
             "address": "vault.example.com",
             "port": 9200,
-            "ssl_verify": False,
         }
 
         with requests_mock.Mocker() as mocker:
@@ -72,7 +70,6 @@ class TestVaultShowCli:
             assert result_json == {
                 "address": "vault.example.com",
                 "port": 9200,
-                "ssl_verify": False,
             }
 
     def test_show_vault_invalid_json(self, caplog):
@@ -183,7 +180,6 @@ class TestVaultShowCli:
         vault_data = {
             "address": "vault.example.com",
             "port": 8200,
-            "ssl_verify": True,
         }
 
         with requests_mock.Mocker() as mocker:

--- a/qpc/tests/vault/test_vault_utils.py
+++ b/qpc/tests/vault/test_vault_utils.py
@@ -83,15 +83,12 @@ class TestVaultUtils:
         parser = ArgumentParser()
         add_vault_arguments(parser, required_certs=True, required_address=True)
 
-        # Check that arguments were added
         args = parser.parse_args(
             [
                 "--address",
                 "vault.example.com",
                 "--port",
                 "8200",
-                "--ssl-verify",
-                "true",
                 "--client-cert",
                 "client.pem",
                 "--client-key",
@@ -103,7 +100,6 @@ class TestVaultUtils:
 
         assert args.address == "vault.example.com"
         assert args.port == 8200
-        assert args.ssl_verify == "true"
         assert args.client_cert == "client.pem"
         assert args.client_key == "client-key.pem"
         assert args.ca_cert == "ca.pem"
@@ -113,12 +109,10 @@ class TestVaultUtils:
         parser = ArgumentParser()
         add_vault_arguments(parser, required_certs=False, required_address=False)
 
-        # Check that arguments can be omitted
         args = parser.parse_args([])
 
         assert args.address is None
         assert args.port == 8200  # default
-        assert args.ssl_verify is None
         assert args.client_cert is None
         assert args.client_key is None
         assert args.ca_cert is None
@@ -136,48 +130,9 @@ class TestVaultUtils:
                 "client.pem",
                 "--client-key",
                 "client-key.pem",
+                "--ca-cert",
+                "ca.pem",
             ]
         )
 
         assert args.port == 8200  # default port
-        assert args.ssl_verify == "true"  # default when required_certs=True
-
-    def test_add_vault_arguments_ssl_verify_false(self):
-        """Test ssl_verify argument with false value."""
-        parser = ArgumentParser()
-        add_vault_arguments(parser, required_certs=True, required_address=True)
-
-        args = parser.parse_args(
-            [
-                "--address",
-                "vault.example.com",
-                "--ssl-verify",
-                "false",
-                "--client-cert",
-                "client.pem",
-                "--client-key",
-                "client-key.pem",
-            ]
-        )
-
-        assert args.ssl_verify == "false"
-
-    def test_add_vault_arguments_ssl_verify_case_insensitive(self):
-        """Test ssl_verify argument is case insensitive."""
-        parser = ArgumentParser()
-        add_vault_arguments(parser, required_certs=True, required_address=True)
-
-        args = parser.parse_args(
-            [
-                "--address",
-                "vault.example.com",
-                "--ssl-verify",
-                "TRUE",
-                "--client-cert",
-                "client.pem",
-                "--client-key",
-                "client-key.pem",
-            ]
-        )
-
-        assert args.ssl_verify == "true"

--- a/qpc/vault/__init__.py
+++ b/qpc/vault/__init__.py
@@ -7,5 +7,3 @@ SHOW = "show"
 CLEAR = "clear"
 
 VAULT_URI = "/api/v2/auth/hashicorp-vault/"
-
-BOOLEAN_CHOICES = ["true", "false"]

--- a/qpc/vault/add.py
+++ b/qpc/vault/add.py
@@ -1,6 +1,5 @@
 """VaultAddCommand is used to add the HashiCorp Vault server configuration."""
 
-import sys
 from logging import getLogger
 
 from requests import codes
@@ -44,14 +43,6 @@ class VaultAddCommand(CliCommand):
         )
         add_vault_arguments(self.parser, required_certs=True)
 
-    def _validate_args(self):
-        """Validate arguments."""
-        CliCommand._validate_args(self)
-        ssl_verify_bool = self.args.ssl_verify == "true"
-        if ssl_verify_bool and not self.args.ca_cert:
-            logger.error(_(messages.VAULT_CA_CERT_REQUIRED))
-            sys.exit(1)
-
     def _build_data(self):
         """Build request payload."""
         client_cert_encoded = read_and_encode_cert_file(
@@ -60,21 +51,15 @@ class VaultAddCommand(CliCommand):
         client_key_encoded = read_and_encode_cert_file(
             self.args.client_key, CERT_TYPE_CLIENT_KEY
         )
-
-        ssl_verify_bool = self.args.ssl_verify == "true"
+        ca_cert_encoded = read_and_encode_cert_file(self.args.ca_cert, CERT_TYPE_CA)
 
         self.req_payload = {
             "address": self.args.address,
             "port": self.args.port,
-            "ssl_verify": ssl_verify_bool,
             "client_cert": client_cert_encoded,
             "client_key": client_key_encoded,
+            "ca_cert": ca_cert_encoded,
         }
-
-        # Add CA cert if provided (required when ssl_verify is True)
-        if self.args.ca_cert:
-            ca_cert_encoded = read_and_encode_cert_file(self.args.ca_cert, CERT_TYPE_CA)
-            self.req_payload["ca_cert"] = ca_cert_encoded
 
     def _handle_response_success(self):
         logger.info(_(messages.VAULT_CONFIG_SUCCESS))

--- a/qpc/vault/edit.py
+++ b/qpc/vault/edit.py
@@ -45,6 +45,11 @@ class VaultEditCommand(CliCommand):
         )
 
         add_vault_arguments(self.parser, required_certs=False, required_address=False)
+        self.parser.usage = (
+            "%(prog)s [--address ADDRESS] [--port PORT]"
+            " [--client-cert CLIENT_CERT_FILE --client-key CLIENT_KEY_FILE]"
+            " [--ca-cert CA_CERT_FILE]"
+        )
         # Override port default to None. For edit, only send if explicitly provided.
         # Also update help text to not show default value
         for action in self.parser._actions:
@@ -64,7 +69,6 @@ class VaultEditCommand(CliCommand):
         has_data = (
             self.args.address
             or self.args.port
-            or self.args.ssl_verify
             or self.args.client_cert
             or self.args.client_key
             or self.args.ca_cert
@@ -81,9 +85,6 @@ class VaultEditCommand(CliCommand):
             self.req_payload["address"] = self.args.address
         if self.args.port:
             self.req_payload["port"] = self.args.port
-        if self.args.ssl_verify is not None:
-            # Convert string "true"/"false" to boolean
-            self.req_payload["ssl_verify"] = self.args.ssl_verify == "true"
 
         # Handle certificate files
         if self.args.client_cert and self.args.client_key:

--- a/qpc/vault/utils.py
+++ b/qpc/vault/utils.py
@@ -5,7 +5,7 @@ import sys
 from logging import getLogger
 from pathlib import Path
 
-from qpc import messages, vault
+from qpc import messages
 from qpc.source.utils import validate_port
 from qpc.translation import _
 
@@ -67,15 +67,6 @@ def add_vault_arguments(parser, required_certs=True, required_address=True):
         required=False,
     )
     parser.add_argument(
-        "--ssl-verify",
-        dest="ssl_verify",
-        choices=vault.BOOLEAN_CHOICES,
-        type=str.lower,
-        default="true" if required_certs else None,
-        help=_(messages.VAULT_SSL_VERIFY_HELP),
-        required=False,
-    )
-    parser.add_argument(
         "--client-cert",
         dest="client_cert",
         metavar="CLIENT_CERT_FILE",
@@ -94,5 +85,5 @@ def add_vault_arguments(parser, required_certs=True, required_address=True):
         dest="ca_cert",
         metavar="CA_CERT_FILE",
         help=_(messages.VAULT_CA_CERT_HELP),
-        required=False,
+        required=required_certs,
     )


### PR DESCRIPTION
- For configuring HashiCorp Vault, ssl_verify is no longer an option and we always require a ca_cert.
- Also Updated tests and man page.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Breaking Changes**
  * Removed the `--ssl-verify` option from Vault add, edit, and show workflows.
  * The `--ca-cert` option is now required when adding a Vault configuration.
  * Vault details no longer display SSL verification settings.
* **Documentation**
  * Updated command help, manual pages, and examples to reflect the revised Vault certificate options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->