### PR TITLE
test: Ensure Jenkins runs on known OpenStack images

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -5,7 +5,7 @@ agents["failFast"] = false
 
 ["fedora", "rhel8", "rhel9", "rhel10"].each { distro_label ->
     agents[distro_label] = {
-        node("discovery_ci && ${distro_label}") {
+        node("openstack && discovery_ci && ${distro_label}") {
             timestamps {
                 stage("[${distro_label}] Setup test environment") {
                     echo "Setting up Quipucords PR tests"


### PR DESCRIPTION
This ensures CI jobs are picked by OpenStack, which is known to work. This is temporary as we transition to AWS.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the CI pipeline’s node selection constraints so distribution-specific stages run only on nodes provisioned for OpenStack.
  * Test stage execution and artifact archiving behavior remain unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->