### PR TITLE
refactor: set QPC_VAR_PROGRAM_NAME to a constant

### DIFF
--- a/deploy/docker_run.sh
+++ b/deploy/docker_run.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 cd /app/qpc
-QPC_VAR_PROGRAM_NAME="${QPC_VAR_PROGRAM_NAME:-qpc}"
+QPC_VAR_PROGRAM_NAME=qpc
 QPC_COMMAND="${1}"
 if [ "${QPC_COMMAND}" = "man" ]; then
   shift

--- a/qpc.spec
+++ b/qpc.spec
@@ -43,7 +43,7 @@ qpc is the command-line client interface for the quipucords server.
 
 %build
 sed -i \
-  -e 's/^QPC_VAR_PROGRAM_NAME = os.environ.get("QPC_VAR_PROGRAM_NAME", "qpc")/QPC_VAR_PROGRAM_NAME = os.environ.get("QPC_VAR_PROGRAM_NAME", "%{binname}")/' \
+  -e 's/^QPC_VAR_PROGRAM_NAME = "qpc"/QPC_VAR_PROGRAM_NAME = "%{binname}"/' \
   %{_builddir}/qpc-%{version}/qpc/release.py
 sed -i \
   -e 's/^qpc = "qpc.__main__:main"$/%{binname} = "qpc.__main__:main"/' \
@@ -51,7 +51,7 @@ sed -i \
 %py3_build
 
 %install
-QPC_VAR_PROGRAM_NAME=%{binname} %py3_install
+%py3_install
 mkdir -p %{buildroot}%{_mandir}/man1/
 sed \
   -e "s/QPC_VAR_PROGRAM_NAME/%{binname}/g" \

--- a/qpc/release.py
+++ b/qpc/release.py
@@ -12,7 +12,7 @@ AUTHOR_EMAIL = "qpc@redhat.com"
 # BEGIN IMPORTANT NOTE: Do not change these lines.
 # Downstream builds may patch these lines to change the program name.
 # See also: https://issues.redhat.com/browse/DISCOVERY-785
-QPC_VAR_PROGRAM_NAME = os.environ.get("QPC_VAR_PROGRAM_NAME", "qpc")
+QPC_VAR_PROGRAM_NAME = "qpc"
 ENTRYPOINT = f"{QPC_VAR_PROGRAM_NAME}=qpc.__main__:main"
 # END IMPORTANT NOTE.
 URL = "https://github.com/quipucords/qpc"


### PR DESCRIPTION
QPC_VAR_PROGRAM_NAME used to be an environment variable, but it was not being used by anyone.
To simplify building downstream, it's being changed to a constant as a part of [DISCOVERY-1244](https://redhat.atlassian.net/browse/DISCOVERY-1244).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Standardized the program name to `qpc` across command-line, container, and packaged installations.
  * Prevented environment settings from overriding the displayed program name.
  * Ensured RPM packaging uses the correct program name during installation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->