### PR TITLE
refactor: Drop paramiko

### DIFF
--- a/docs/_build/QPC_VAR_PROGRAM_NAME.1
+++ b/docs/_build/QPC_VAR_PROGRAM_NAME.1
@@ -311,7 +311,7 @@ When you configure a scan, it contains references to one or more sources, includ
 .sp
 To create a source, supply the type of source with the \fBtype\fP option, one or more host names or IP addresses to connect to with the \fB\-\-hosts\fP option, and the credentials needed to access those systems with the \fB\-\-cred\fP option. The \fBQPC_VAR_PROGRAM_NAME source\fP command allows multiple entries for the \fBhosts\fP and \fBcred\fP options. Therefore, a single source can access a collection of servers and subnets as needed to create an accurate and complete scan.
 .sp
-\fBQPC_VAR_PROGRAM_NAME source add \-\-name=\fP \fIname\fP  \fB\-\-type=\fP \fI(network | vcenter | satellite | openshift | rhacs | ansible)\fP \fB\-\-hosts\fP \fIip_address\fP \fB\-\-cred\fP \fIcredential\fP \fB[\-\-exclude\-hosts\fP \fIip_address\fP \fB]\fP \fB[\-\-port=\fP \fIport\fP \fB]\fP \fB[\-\-use\-paramiko=\fP \fI(True | False)\fP \fB]\fP \fB[\-\-ssl\-cert\-verify=\fP \fI(True | False)\fP \fB]\fP \fB[\-\-ssl\-protocol=\fP \fIprotocol\fP \fB]\fP \fB[\-\-disable\-ssl=\fP \fI(True | False)\fP \fB]\fP \fB[\-\-proxy\-url=\fP \fIproxy url\fP \fB]\fP
+\fBQPC_VAR_PROGRAM_NAME source add \-\-name=\fP \fIname\fP  \fB\-\-type=\fP \fI(network | vcenter | satellite | openshift | rhacs | ansible)\fP \fB\-\-hosts\fP \fIip_address\fP \fB\-\-cred\fP \fIcredential\fP \fB[\-\-exclude\-hosts\fP \fIip_address\fP \fB]\fP \fB[\-\-port=\fP \fIport\fP \fB]\fP \fB[\-\-ssl\-cert\-verify=\fP \fI(True | False)\fP \fB]\fP \fB[\-\-ssl\-protocol=\fP \fIprotocol\fP \fB]\fP \fB[\-\-disable\-ssl=\fP \fI(True | False)\fP \fB]\fP \fB[\-\-proxy\-url=\fP \fIproxy url\fP \fB]\fP
 .sp
 \fB\-\-name=name\fP
 .INDENT 0.0
@@ -379,13 +379,6 @@ Optional. Sets a port to be used for the scan. This value supports connection an
 .UNINDENT
 .UNINDENT
 .sp
-\fB\-\-use\-paramiko=(True | False)\fP
-.INDENT 0.0
-.INDENT 3.5
-Optional. Changes the Ansible connection method from the default open\-ssh to the python ssh implementation.
-.UNINDENT
-.UNINDENT
-.sp
 \fB\-\-ssl\-cert\-verify=(True | False)\fP
 .INDENT 0.0
 .INDENT 3.5
@@ -419,7 +412,7 @@ The information in a source might change as the structure of the network changes
 .sp
 Although \fBQPC_VAR_PROGRAM_NAME source\fP options can accept more than one value, the \fBQPC_VAR_PROGRAM_NAME source edit\fP command is not additive. To edit a source and add a new value for an option, you must enter both the current and the new values for that option. Include only the options that you want to change in the \fBQPC_VAR_PROGRAM_NAME source edit\fP command. Options that are not included are not changed.
 .sp
-\fBQPC_VAR_PROGRAM_NAME source edit \-\-name\fP \fIname\fP \fB[\-\-hosts\fP \fIip_address\fP \fB] [\-\-cred\fP \fIcredential\fP \fB] **[\-\-exclude\-hosts\fP \fIip_address\fP \fB] [\-\-port=\fP \fIport\fP \fB]\fP \fB[\-\-use\-paramiko=\fP \fI(True | False)\fP \fB]\fP \fB[\-\-ssl\-cert\-verify=\fP \fI(True | False)\fP \fB]\fP \fB[\-\-ssl\-protocol=\fP \fIprotocol\fP \fB]\fP \fB[\-\-disable\-ssl=\fP \fI(True | False)\fP \fB]\fP
+\fBQPC_VAR_PROGRAM_NAME source edit \-\-name\fP \fIname\fP \fB[\-\-hosts\fP \fIip_address\fP \fB] [\-\-cred\fP \fIcredential\fP \fB] **[\-\-exclude\-hosts\fP \fIip_address\fP \fB] [\-\-port=\fP \fIport\fP \fB]\fP \fB[\-\-ssl\-cert\-verify=\fP \fI(True | False)\fP \fB]\fP \fB[\-\-ssl\-protocol=\fP \fIprotocol\fP \fB]\fP \fB[\-\-disable\-ssl=\fP \fI(True | False)\fP \fB]\fP
 .sp
 For example, if a source contains a value of \fBserver1creds\fP for the \fB\-\-cred\fP option, and you want to change that source to use both the \fBserver1creds\fP and \fBserver2creds\fP credentials, you would edit the source as follows:
 .sp

--- a/docs/_build/man-qpc.rst
+++ b/docs/_build/man-qpc.rst
@@ -254,7 +254,7 @@ Creating and Editing Sources
 
 To create a source, supply the type of source with the ``type`` option, one or more host names or IP addresses to connect to with the ``--hosts`` option, and the credentials needed to access those systems with the ``--cred`` option. The ``qpc source`` command allows multiple entries for the ``hosts`` and ``cred`` options. Therefore, a single source can access a collection of servers and subnets as needed to create an accurate and complete scan.
 
-**qpc source add --name=** *name*  **--type=** *(network | vcenter | satellite | openshift | rhacs | ansible)* **--hosts** *ip_address* **--cred** *credential* **[--exclude-hosts** *ip_address* **]** **[--port=** *port* **]** **[--use-paramiko=** *(True | False)* **]** **[--ssl-cert-verify=** *(True | False)* **]** **[--ssl-protocol=** *protocol* **]** **[--disable-ssl=** *(True | False)* **]** **[--proxy-url=** *proxy url* **]**
+**qpc source add --name=** *name*  **--type=** *(network | vcenter | satellite | openshift | rhacs | ansible)* **--hosts** *ip_address* **--cred** *credential* **[--exclude-hosts** *ip_address* **]** **[--port=** *port* **]** **[--ssl-cert-verify=** *(True | False)* **]** **[--ssl-protocol=** *protocol* **]** **[--disable-ssl=** *(True | False)* **]** **[--proxy-url=** *proxy url* **]**
 
 ``--name=name``
 
@@ -302,10 +302,6 @@ To create a source, supply the type of source with the ``type`` option, one or m
 
   Optional. Sets a port to be used for the scan. This value supports connection and inspection on a non-standard port. By default, a Network scan uses port 22, vCenter, Ansible, RHACS and Satellite scans use port 443, and an Openshift scan uses port 6443.
 
-``--use-paramiko=(True | False)``
-
-  Optional. Changes the Ansible connection method from the default open-ssh to the python ssh implementation.
-
 ``--ssl-cert-verify=(True | False)``
 
   Optional. Determines whether SSL certificate validation will be performed for the scan.
@@ -327,7 +323,7 @@ The information in a source might change as the structure of the network changes
 
 Although ``qpc source`` options can accept more than one value, the ``qpc source edit`` command is not additive. To edit a source and add a new value for an option, you must enter both the current and the new values for that option. Include only the options that you want to change in the ``qpc source edit`` command. Options that are not included are not changed.
 
-**qpc source edit --name** *name* **[--hosts** *ip_address* **] [--cred** *credential* **] **[--exclude-hosts** *ip_address* **] [--port=** *port* **]** **[--use-paramiko=** *(True | False)* **]** **[--ssl-cert-verify=** *(True | False)* **]** **[--ssl-protocol=** *protocol* **]** **[--disable-ssl=** *(True | False)* **]**
+**qpc source edit --name** *name* **[--hosts** *ip_address* **] [--cred** *credential* **] **[--exclude-hosts** *ip_address* **] [--port=** *port* **]** **[--ssl-cert-verify=** *(True | False)* **]** **[--ssl-protocol=** *protocol* **]** **[--disable-ssl=** *(True | False)* **]**
 
 For example, if a source contains a value of ``server1creds`` for the ``--cred`` option, and you want to change that source to use both the ``server1creds`` and ``server2creds`` credentials, you would edit the source as follows:
 

--- a/docs/_build/qpc.1
+++ b/docs/_build/qpc.1
@@ -311,7 +311,7 @@ When you configure a scan, it contains references to one or more sources, includ
 .sp
 To create a source, supply the type of source with the \fBtype\fP option, one or more host names or IP addresses to connect to with the \fB\-\-hosts\fP option, and the credentials needed to access those systems with the \fB\-\-cred\fP option. The \fBqpc source\fP command allows multiple entries for the \fBhosts\fP and \fBcred\fP options. Therefore, a single source can access a collection of servers and subnets as needed to create an accurate and complete scan.
 .sp
-\fBqpc source add \-\-name=\fP \fIname\fP  \fB\-\-type=\fP \fI(network | vcenter | satellite | openshift | rhacs | ansible)\fP \fB\-\-hosts\fP \fIip_address\fP \fB\-\-cred\fP \fIcredential\fP \fB[\-\-exclude\-hosts\fP \fIip_address\fP \fB]\fP \fB[\-\-port=\fP \fIport\fP \fB]\fP \fB[\-\-use\-paramiko=\fP \fI(True | False)\fP \fB]\fP \fB[\-\-ssl\-cert\-verify=\fP \fI(True | False)\fP \fB]\fP \fB[\-\-ssl\-protocol=\fP \fIprotocol\fP \fB]\fP \fB[\-\-disable\-ssl=\fP \fI(True | False)\fP \fB]\fP \fB[\-\-proxy\-url=\fP \fIproxy url\fP \fB]\fP
+\fBqpc source add \-\-name=\fP \fIname\fP  \fB\-\-type=\fP \fI(network | vcenter | satellite | openshift | rhacs | ansible)\fP \fB\-\-hosts\fP \fIip_address\fP \fB\-\-cred\fP \fIcredential\fP \fB[\-\-exclude\-hosts\fP \fIip_address\fP \fB]\fP \fB[\-\-port=\fP \fIport\fP \fB]\fP \fB[\-\-ssl\-cert\-verify=\fP \fI(True | False)\fP \fB]\fP \fB[\-\-ssl\-protocol=\fP \fIprotocol\fP \fB]\fP \fB[\-\-disable\-ssl=\fP \fI(True | False)\fP \fB]\fP \fB[\-\-proxy\-url=\fP \fIproxy url\fP \fB]\fP
 .sp
 \fB\-\-name=name\fP
 .INDENT 0.0
@@ -379,13 +379,6 @@ Optional. Sets a port to be used for the scan. This value supports connection an
 .UNINDENT
 .UNINDENT
 .sp
-\fB\-\-use\-paramiko=(True | False)\fP
-.INDENT 0.0
-.INDENT 3.5
-Optional. Changes the Ansible connection method from the default open\-ssh to the python ssh implementation.
-.UNINDENT
-.UNINDENT
-.sp
 \fB\-\-ssl\-cert\-verify=(True | False)\fP
 .INDENT 0.0
 .INDENT 3.5
@@ -419,7 +412,7 @@ The information in a source might change as the structure of the network changes
 .sp
 Although \fBqpc source\fP options can accept more than one value, the \fBqpc source edit\fP command is not additive. To edit a source and add a new value for an option, you must enter both the current and the new values for that option. Include only the options that you want to change in the \fBqpc source edit\fP command. Options that are not included are not changed.
 .sp
-\fBqpc source edit \-\-name\fP \fIname\fP \fB[\-\-hosts\fP \fIip_address\fP \fB] [\-\-cred\fP \fIcredential\fP \fB] **[\-\-exclude\-hosts\fP \fIip_address\fP \fB] [\-\-port=\fP \fIport\fP \fB]\fP \fB[\-\-use\-paramiko=\fP \fI(True | False)\fP \fB]\fP \fB[\-\-ssl\-cert\-verify=\fP \fI(True | False)\fP \fB]\fP \fB[\-\-ssl\-protocol=\fP \fIprotocol\fP \fB]\fP \fB[\-\-disable\-ssl=\fP \fI(True | False)\fP \fB]\fP
+\fBqpc source edit \-\-name\fP \fIname\fP \fB[\-\-hosts\fP \fIip_address\fP \fB] [\-\-cred\fP \fIcredential\fP \fB] **[\-\-exclude\-hosts\fP \fIip_address\fP \fB] [\-\-port=\fP \fIport\fP \fB]\fP \fB[\-\-ssl\-cert\-verify=\fP \fI(True | False)\fP \fB]\fP \fB[\-\-ssl\-protocol=\fP \fIprotocol\fP \fB]\fP \fB[\-\-disable\-ssl=\fP \fI(True | False)\fP \fB]\fP
 .sp
 For example, if a source contains a value of \fBserver1creds\fP for the \fB\-\-cred\fP option, and you want to change that source to use both the \fBserver1creds\fP and \fBserver2creds\fP credentials, you would edit the source as follows:
 .sp

--- a/docs/source/man-template.rst
+++ b/docs/source/man-template.rst
@@ -254,7 +254,7 @@ Creating and Editing Sources
 
 To create a source, supply the type of source with the ``type`` option, one or more host names or IP addresses to connect to with the ``--hosts`` option, and the credentials needed to access those systems with the ``--cred`` option. The ``QPC_VAR_PROGRAM_NAME source`` command allows multiple entries for the ``hosts`` and ``cred`` options. Therefore, a single source can access a collection of servers and subnets as needed to create an accurate and complete scan.
 
-**QPC_VAR_PROGRAM_NAME source add --name=** *name*  **--type=** *(network | vcenter | satellite | openshift | rhacs | ansible)* **--hosts** *ip_address* **--cred** *credential* **[--exclude-hosts** *ip_address* **]** **[--port=** *port* **]** **[--use-paramiko=** *(True | False)* **]** **[--ssl-cert-verify=** *(True | False)* **]** **[--ssl-protocol=** *protocol* **]** **[--disable-ssl=** *(True | False)* **]** **[--proxy-url=** *proxy url* **]**
+**QPC_VAR_PROGRAM_NAME source add --name=** *name*  **--type=** *(network | vcenter | satellite | openshift | rhacs | ansible)* **--hosts** *ip_address* **--cred** *credential* **[--exclude-hosts** *ip_address* **]** **[--port=** *port* **]** **[--ssl-cert-verify=** *(True | False)* **]** **[--ssl-protocol=** *protocol* **]** **[--disable-ssl=** *(True | False)* **]** **[--proxy-url=** *proxy url* **]**
 
 ``--name=name``
 
@@ -302,10 +302,6 @@ To create a source, supply the type of source with the ``type`` option, one or m
 
   Optional. Sets a port to be used for the scan. This value supports connection and inspection on a non-standard port. By default, a Network scan uses port 22, vCenter, Ansible, RHACS and Satellite scans use port 443, and an Openshift scan uses port 6443.
 
-``--use-paramiko=(True | False)``
-
-  Optional. Changes the Ansible connection method from the default open-ssh to the python ssh implementation.
-
 ``--ssl-cert-verify=(True | False)``
 
   Optional. Determines whether SSL certificate validation will be performed for the scan.
@@ -327,7 +323,7 @@ The information in a source might change as the structure of the network changes
 
 Although ``QPC_VAR_PROGRAM_NAME source`` options can accept more than one value, the ``QPC_VAR_PROGRAM_NAME source edit`` command is not additive. To edit a source and add a new value for an option, you must enter both the current and the new values for that option. Include only the options that you want to change in the ``QPC_VAR_PROGRAM_NAME source edit`` command. Options that are not included are not changed.
 
-**QPC_VAR_PROGRAM_NAME source edit --name** *name* **[--hosts** *ip_address* **] [--cred** *credential* **] **[--exclude-hosts** *ip_address* **] [--port=** *port* **]** **[--use-paramiko=** *(True | False)* **]** **[--ssl-cert-verify=** *(True | False)* **]** **[--ssl-protocol=** *protocol* **]** **[--disable-ssl=** *(True | False)* **]**
+**QPC_VAR_PROGRAM_NAME source edit --name** *name* **[--hosts** *ip_address* **] [--cred** *credential* **] **[--exclude-hosts** *ip_address* **] [--port=** *port* **]** **[--ssl-cert-verify=** *(True | False)* **]** **[--ssl-protocol=** *protocol* **]** **[--disable-ssl=** *(True | False)* **]**
 
 For example, if a source contains a value of ``server1creds`` for the ``--cred`` option, and you want to change that source to use both the ``server1creds`` and ``server2creds`` credentials, you would edit the source as follows:
 

--- a/qpc/messages.py
+++ b/qpc/messages.py
@@ -108,9 +108,6 @@ SOURCE_PORT_HELP = (
     "Port to use for connection for the scan; "
     "network default is 22, vcenter default is 443."
 )
-SOURCE_PARAMIKO_HELP = (
-    "Set Ansible connection method to paramiko. default connection method is ssh."
-)
 SOURCE_SSL_CERT_HELP = (
     "If true, the SSL certificate will"
     " be verified when making requests to the source, otherwise no "

--- a/qpc/source/add.py
+++ b/qpc/source/add.py
@@ -110,14 +110,6 @@ class SourceAddCommand(CliCommand):
             required=False,
         )
         self.parser.add_argument(
-            "--use-paramiko",
-            dest="use_paramiko",
-            choices=source.BOOLEAN_CHOICES,
-            type=str.lower,
-            help=_(messages.SOURCE_PARAMIKO_HELP),
-            required=False,
-        )
-        self.parser.add_argument(
             "--proxy-url",
             dest="proxy_url",
             metavar="PROXY_URL",

--- a/qpc/source/edit.py
+++ b/qpc/source/edit.py
@@ -100,14 +100,6 @@ class SourceEditCommand(CliCommand):
             required=False,
         )
         self.parser.add_argument(
-            "--use-paramiko",
-            dest="use_paramiko",
-            choices=source.BOOLEAN_CHOICES,
-            type=str.lower,
-            help=_(messages.SOURCE_PARAMIKO_HELP),
-            required=False,
-        )
-        self.parser.add_argument(
             "--proxy-url",
             dest="proxy_url",
             metavar="PROXY_URL",
@@ -123,7 +115,6 @@ class SourceEditCommand(CliCommand):
             or self.args.exclude_hosts
             or self.args.cred
             or self.args.port
-            or self.args.use_paramiko
             or self.args.ssl_cert_verify
             or self.args.disable_ssl
             or self.args.ssl_protocol

--- a/qpc/source/utils.py
+++ b/qpc/source/utils.py
@@ -65,8 +65,6 @@ def build_source_payload(args, add_none=True):  # noqa: C901 PLR0912
         req_payload["disable_ssl"] = args.disable_ssl == "true"
     if hasattr(args, "ssl_protocol") and args.ssl_protocol is not None:
         req_payload["ssl_protocol"] = args.ssl_protocol
-    if hasattr(args, "use_paramiko") and args.use_paramiko is not None:
-        req_payload["use_paramiko"] = args.use_paramiko
     if hasattr(args, "proxy_url") and args.proxy_url:
         req_payload["proxy_url"] = args.proxy_url
     elif add_none:

--- a/qpc/tests/source/test_source_add.py
+++ b/qpc/tests/source/test_source_add.py
@@ -275,58 +275,6 @@ class TestSourceAddCli:
                 expected_message = messages.SOURCE_ADDED % "source1"
                 assert expected_message in caplog.text
 
-    def test_add_source_with_paramiko(self, caplog):
-        """Testing add network source command with use_paramiko set to true."""
-        get_cred_url = get_server_location() + CREDENTIAL_URI + "?name=cred1"
-        cred_results = [{"id": 1, "name": "cred1"}]
-        get_cred_data = {"count": 1, "results": cred_results}
-        post_source_url = get_server_location() + SOURCE_URI
-        with requests_mock.Mocker() as mocker:
-            mocker.get(get_cred_url, status_code=200, json=get_cred_data)
-            mocker.post(post_source_url, status_code=201)
-
-            args = Namespace(
-                name="source1",
-                cred=["cred1"],
-                hosts=["10.10.181.9"],
-                use_paramiko=True,
-                type="network",
-                port=22,
-            )
-
-            with caplog.at_level(logging.INFO):
-                self.command.main(args)
-                expected_message = messages.SOURCE_ADDED % "source1"
-                assert expected_message in caplog.text
-
-    def test_add_source_with_paramiko_and_ssl(self, caplog):
-        """Testing add network source command with use_paramiko set to true."""
-        get_cred_url = get_server_location() + CREDENTIAL_URI + "?name=cred1"
-        cred_results = [{"id": 1, "name": "cred1"}]
-        get_cred_data = {"count": 1, "results": cred_results}
-        post_source_url = get_server_location() + SOURCE_URI
-        with requests_mock.Mocker() as mocker:
-            mocker.get(get_cred_url, status_code=200, json=get_cred_data)
-            mocker.post(post_source_url, status_code=400)
-
-            args = Namespace(
-                name="source1",
-                cred=["cred1"],
-                hosts=["10.10.181.9"],
-                ssl_cert_verify="False",
-                use_paramiko=True,
-                type="network",
-                port=22,
-            )
-            with pytest.raises(SystemExit), caplog.at_level(logging.ERROR):
-                self.command.main(args)
-            # TODO Assert *something* meaningful is in the output!
-            # assert caplog.text
-            # FIXME utils.handle_error_response does literally nothing if the
-            #  server's response is not JSON (raises JSONDecodeError).
-            #  This means the process simply exits with NO OUTPUT.
-            # TODO Underlying code needs a thorough evaluation and rewrite.
-
     def test_add_source_one_excludehost(self, caplog):
         """Testing the add network source command with one exclude host."""
         get_cred_url = get_server_location() + CREDENTIAL_URI + "?name=cred1"

--- a/qpc/tests/source/test_source_utils.py
+++ b/qpc/tests/source/test_source_utils.py
@@ -53,7 +53,6 @@ class TestBuildSourcePayloadV2:
                 "ssl_cert_verify": "true",
                 "disable_ssl": "false",
                 "ssl_protocol": "TLSv1_1",
-                "use_paramiko": "true",
             }
         )
         result = build_source_payload(args)
@@ -67,7 +66,6 @@ class TestBuildSourcePayloadV2:
             "ssl_cert_verify": True,
             "disable_ssl": False,
             "ssl_protocol": "TLSv1_1",
-            "use_paramiko": "true",
             "proxy_url": None,
         }
 


### PR DESCRIPTION
Drop Paramiko option from Network scan for [DISCOVERY-1482](https://redhat.atlassian.net/browse/DISCOVERY-1482)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Removed**
  * Removed the `--use-paramiko` option from source creation and editing commands.
  * Source configurations can no longer select Paramiko through the CLI.
  * Removed related option details from the command-line documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->