### PR TITLE
Bump uv lower bound to 0.11

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,7 @@ default-groups = [
     "dev",
     "build",
 ]
-required-version = ">=0.7"
+required-version = ">=0.11"
 
 [tool.hatch.build.targets.sdist]
 exclude = [


### PR DESCRIPTION
This should prevent uv.lock revision field from jumping back and forth between 2 and 3.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the required uv version to 0.11 or newer.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->